### PR TITLE
creating configs from an existing toJSON() object

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 
 * [Configuration](./config.schema.md) – `https://ns.adobe.com/helix/shared/config` (Stabilizing)
 * [Git URL](./giturl.schema.md) – `https://ns.adobe.com/helix/shared/giturl` (Stabilizing)
+* [Git URL](./staticgiturl.schema.md) – `https://ns.adobe.com/helix/shared/staticgiturl` (Stabilizing)
 * [Origin](./origin.schema.md) – `https://ns.adobe.com/helix/shared/origin` (Stabilizing)
 * [Proxy Strain](./proxystrain.schema.md) – `https://ns.adobe.com/helix/shared/proxystrain` (Stabilizing)
 * [Runtime Strain](./performance.schema.md) – `https://ns.adobe.com/helix/shared/performance` (Stabilizing)

--- a/docs/giturl.schema.json
+++ b/docs/giturl.schema.json
@@ -30,11 +30,18 @@
         "hostname": {
             "description": "The hostname without port",
             "type": "string",
-            "pattern": "hostname"
+            "format": "hostname"
+        },
+        "host": {
+            "description": "The hostname with port",
+            "type": "string"
         },
         "port": {
             "description": "The port to access the Git Repository",
-            "type": "integer"
+            "type": [
+                "integer",
+                "string"
+            ]
         },
         "owner": {
             "description": "The owner or username that the repository belongs to",

--- a/docs/giturl.schema.md
+++ b/docs/giturl.schema.md
@@ -15,13 +15,35 @@ Representation of the fragments of a Git URL
 
 | Property | Type | Required | Default | Defined by |
 |----------|------|----------|---------|------------|
+| [host](#host) | `string` | Optional |  | Git URL (this schema) |
 | [hostname](#hostname) | `string` | Optional |  | Git URL (this schema) |
 | [owner](#owner) | `string` | **Required** |  | Git URL (this schema) |
 | [path](#path) | `string` | Optional |  | Git URL (this schema) |
-| [port](#port) | `integer` | Optional |  | Git URL (this schema) |
+| [port](#port) | complex | Optional |  | Git URL (this schema) |
 | [protocol](#protocol) | `enum` | Optional |  | Git URL (this schema) |
 | [ref](#ref) | `string` | **Required** | `"master"` | Git URL (this schema) |
 | [repo](#repo) | `string` | **Required** |  | Git URL (this schema) |
+
+## host
+
+The hostname with port
+
+`host`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### host Type
+
+
+`string`
+
+
+
+
+
+
 
 ## hostname
 
@@ -38,13 +60,7 @@ The hostname without port
 
 `string`
 
-
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=hostname)):
-```regex
-hostname
-```
+* format: `hostname` – Domain Name (according to [RFC 1034, section 3.1](https://tools.ietf.org/html/rfc1034))
 
 
 
@@ -100,15 +116,23 @@ The port to access the Git Repository
 `port`
 
 * is optional
-* type: `integer`
+* type: complex
 * defined in this schema
 
 ### port Type
 
+Unknown type `integer,string`.
 
-`integer`
-
-
+```json
+{
+  "description": "The port to access the Git Repository",
+  "type": [
+    "integer",
+    "string"
+  ],
+  "simpletype": "complex"
+}
+```
 
 
 

--- a/docs/origin.schema.json
+++ b/docs/origin.schema.json
@@ -70,17 +70,5 @@
             "type": "boolean",
             "description": ""
         }
-    },
-    "oneOf": [
-        {
-            "required": [
-                "hostname"
-            ]
-        },
-        {
-            "required": [
-                "address"
-            ]
-        }
-    ]
+    }
 }

--- a/docs/proxystrain.schema.json
+++ b/docs/proxystrain.schema.json
@@ -20,7 +20,7 @@
     "properties": {
         "origin": {
             "description": "Origin backend for proxy strains.",
-            "oneOf": [
+            "anyOf": [
                 {
                     "type": "string",
                     "format": "uri"
@@ -53,6 +53,13 @@
         },
         "perf": {
             "$ref": "https://ns.adobe.com/helix/shared/performance"
+        },
+        "params": {
+            "description": "A whitelist (using globbing language) of URL parameters. Note: every parameter is a potential cache killer.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "required": [

--- a/docs/proxystrain.schema.md
+++ b/docs/proxystrain.schema.md
@@ -22,6 +22,7 @@ A strain is a combination of code and content that enables the creation of a dig
 |----------|------|----------|------------|
 | [condition](#condition) | `string` | Optional | Proxy Strain (this schema) |
 | [origin](#origin) | complex | **Required** | Proxy Strain (this schema) |
+| [params](#params) | `string[]` | Optional | Proxy Strain (this schema) |
 | [perf](#perf) | Runtime Strain | Optional | Proxy Strain (this schema) |
 | [sticky](#sticky) | `boolean` | Optional | Proxy Strain (this schema) |
 | [url](#url) | `string` | Optional | Proxy Strain (this schema) |
@@ -61,10 +62,10 @@ Origin backend for proxy strains.
 ### origin Type
 
 
-**One** of the following *conditions* need to be fulfilled.
+**Any** following *options* needs to be fulfilled.
 
 
-#### Condition 1
+#### Option 1
 
 
 `string`
@@ -73,10 +74,37 @@ Origin backend for proxy strains.
 
 
 
-#### Condition 2
+#### Option 2
 
 
 * []() – `https://ns.adobe.com/helix/shared/origin`
+
+
+
+
+
+
+## params
+
+A whitelist (using globbing language) of URL parameters. Note: every parameter is a potential cache killer.
+
+`params`
+
+* is optional
+* type: `string[]`
+* defined in this schema
+
+### params Type
+
+
+Array type: `string[]`
+
+All items must be of the type:
+`string`
+
+
+
+
 
 
 

--- a/docs/runtimestrain.schema.json
+++ b/docs/runtimestrain.schema.json
@@ -50,7 +50,7 @@
                     "format": "uri"
                 },
                 {
-                    "$ref": "https://ns.adobe.com/helix/shared/giturl"
+                    "$ref": "https://ns.adobe.com/helix/shared/staticgiturl"
                 }
             ]
         },
@@ -86,6 +86,13 @@
         },
         "perf": {
             "$ref": "https://ns.adobe.com/helix/shared/performance"
+        },
+        "params": {
+            "description": "A whitelist (using globbing language) of URL parameters. Note: every parameter is a potential cache killer.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "required": [

--- a/docs/runtimestrain.schema.md
+++ b/docs/runtimestrain.schema.md
@@ -25,6 +25,7 @@ A runtime strain is a combination of code and content that enables the creation 
 | [content](#content) | complex | **Required** |  | Runtime Strain (this schema) |
 | [directoryIndex](#directoryindex) | `string` | Optional | `"index.html"` | Runtime Strain (this schema) |
 | [package](#package) | `string` | Optional |  | Runtime Strain (this schema) |
+| [params](#params) | `string[]` | Optional |  | Runtime Strain (this schema) |
 | [perf](#perf) | Runtime Strain | Optional |  | Runtime Strain (this schema) |
 | [static](#static) | complex | **Required** |  | Runtime Strain (this schema) |
 | [sticky](#sticky) | `boolean` | Optional |  | Runtime Strain (this schema) |
@@ -165,6 +166,33 @@ Name of the action package that renders this strain.
 
 
 
+## params
+
+A whitelist (using globbing language) of URL parameters. Note: every parameter is a potential cache killer.
+
+`params`
+
+* is optional
+* type: `string[]`
+* defined in this schema
+
+### params Type
+
+
+Array type: `string[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
+
+
+
+
+
 ## perf
 
 
@@ -211,7 +239,7 @@ Pointer to the repository for static resources
 #### Condition 2
 
 
-* []() – `https://ns.adobe.com/helix/shared/giturl`
+* []() – `https://ns.adobe.com/helix/shared/staticgiturl`
 
 
 

--- a/docs/staticgiturl.schema.json
+++ b/docs/staticgiturl.schema.json
@@ -1,0 +1,87 @@
+{
+    "meta:license": [
+        "Copyright 2019 Adobe. All rights reserved.",
+        "This file is licensed to you under the Apache License, Version 2.0 (the \"License\");",
+        "you may not use this file except in compliance with the License. You may obtain a copy",
+        "of the License at http://www.apache.org/licenses/LICENSE-2.0",
+        "",
+        "Unless required by applicable law or agreed to in writing, software distributed under",
+        "the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS",
+        "OF ANY KIND, either express or implied. See the License for the specific language",
+        "governing permissions and limitations under the License."
+    ],
+    "$id": "https://ns.adobe.com/helix/shared/staticgiturl",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Git URL",
+    "type": "object",
+    "meta:status": "stabilizing",
+    "description": "Representation of the fragments of a Git URL",
+    "additionalProperties": false,
+    "properties": {
+        "protocol": {
+            "description": "The protocol to access the Git repository",
+            "enum": [
+                "https",
+                "http",
+                "ssh"
+            ],
+            "type": "string"
+        },
+        "hostname": {
+            "description": "The hostname without port",
+            "type": "string",
+            "format": "hostname"
+        },
+        "host": {
+            "description": "The hostname with port",
+            "type": "string"
+        },
+        "port": {
+            "description": "The port to access the Git Repository",
+            "type": [
+                "integer",
+                "string"
+            ]
+        },
+        "owner": {
+            "description": "The owner or username that the repository belongs to",
+            "type": "string"
+        },
+        "path": {
+            "description": "The path within the repository",
+            "type": "string"
+        },
+        "repo": {
+            "description": "The repository name",
+            "type": "string"
+        },
+        "ref": {
+            "description": "The branch, tag, or sha of the tree in the repository to use",
+            "default": "master",
+            "type": "string"
+        },
+        "allow": {
+            "description": "List of white listed paths",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "deny": {
+            "description": "List of white listed paths",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "magic": {
+            "type": "boolean",
+            "description": "Deprecated: Enable server-side asset processing."
+        }
+    },
+    "required": [
+        "owner",
+        "repo",
+        "ref"
+    ]
+}

--- a/docs/staticgiturl.schema.md
+++ b/docs/staticgiturl.schema.md
@@ -1,0 +1,280 @@
+
+# Git URL Schema
+
+```
+https://ns.adobe.com/helix/shared/staticgiturl
+```
+
+Representation of the fragments of a Git URL
+
+| Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------|------------|--------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Stabilizing | No | Forbidden | Forbidden | [staticgiturl.schema.json](staticgiturl.schema.json) |
+
+# Git URL Properties
+
+| Property | Type | Required | Default | Defined by |
+|----------|------|----------|---------|------------|
+| [allow](#allow) | `string[]` | Optional |  | Git URL (this schema) |
+| [deny](#deny) | `string[]` | Optional |  | Git URL (this schema) |
+| [host](#host) | `string` | Optional |  | Git URL (this schema) |
+| [hostname](#hostname) | `string` | Optional |  | Git URL (this schema) |
+| [magic](#magic) | `boolean` | Optional |  | Git URL (this schema) |
+| [owner](#owner) | `string` | **Required** |  | Git URL (this schema) |
+| [path](#path) | `string` | Optional |  | Git URL (this schema) |
+| [port](#port) | complex | Optional |  | Git URL (this schema) |
+| [protocol](#protocol) | `enum` | Optional |  | Git URL (this schema) |
+| [ref](#ref) | `string` | **Required** | `"master"` | Git URL (this schema) |
+| [repo](#repo) | `string` | **Required** |  | Git URL (this schema) |
+
+## allow
+
+List of white listed paths
+
+`allow`
+
+* is optional
+* type: `string[]`
+* defined in this schema
+
+### allow Type
+
+
+Array type: `string[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
+
+
+
+
+
+## deny
+
+List of white listed paths
+
+`deny`
+
+* is optional
+* type: `string[]`
+* defined in this schema
+
+### deny Type
+
+
+Array type: `string[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
+
+
+
+
+
+## host
+
+The hostname with port
+
+`host`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### host Type
+
+
+`string`
+
+
+
+
+
+
+
+## hostname
+
+The hostname without port
+
+`hostname`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### hostname Type
+
+
+`string`
+
+* format: `hostname` – Domain Name (according to [RFC 1034, section 3.1](https://tools.ietf.org/html/rfc1034))
+
+
+
+
+
+
+## magic
+
+Deprecated: Enable server-side asset processing.
+
+`magic`
+
+* is optional
+* type: `boolean`
+* defined in this schema
+
+### magic Type
+
+
+`boolean`
+
+
+
+
+
+## owner
+
+The owner or username that the repository belongs to
+
+`owner`
+
+* is **required**
+* type: `string`
+* defined in this schema
+
+### owner Type
+
+
+`string`
+
+
+
+
+
+
+
+## path
+
+The path within the repository
+
+`path`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### path Type
+
+
+`string`
+
+
+
+
+
+
+
+## port
+
+The port to access the Git Repository
+
+`port`
+
+* is optional
+* type: complex
+* defined in this schema
+
+### port Type
+
+Unknown type `integer,string`.
+
+```json
+{
+  "description": "The port to access the Git Repository",
+  "type": [
+    "integer",
+    "string"
+  ],
+  "simpletype": "complex"
+}
+```
+
+
+
+
+
+## protocol
+
+The protocol to access the Git repository
+
+`protocol`
+
+* is optional
+* type: `enum`
+* defined in this schema
+
+The value of this property **must** be equal to one of the [known values below](#protocol-known-values).
+
+### protocol Known Values
+| Value | Description |
+|-------|-------------|
+| `https` |  |
+| `http` |  |
+| `ssh` |  |
+
+
+
+
+## ref
+
+The branch, tag, or sha of the tree in the repository to use
+
+`ref`
+
+* is **required**
+* type: `string`
+* default: `"master"`
+* defined in this schema
+
+### ref Type
+
+
+`string`
+
+
+
+
+
+
+
+## repo
+
+The repository name
+
+`repo`
+
+* is **required**
+* type: `string`
+* defined in this schema
+
+### repo Type
+
+
+`string`
+
+
+
+
+
+

--- a/src/ConfigValidator.js
+++ b/src/ConfigValidator.js
@@ -18,6 +18,7 @@ const schemas = [
   require('./schemas/proxystrain.schema.json'),
   require('./schemas/strains.schema.json'),
   require('./schemas/giturl.schema.json'),
+  require('./schemas/staticgiturl.schema.json'),
   require('./schemas/origin.schema.json'),
   require('./schemas/performance.schema.json'),
   /* eslint-enable global-require */

--- a/src/HelixConfig.js
+++ b/src/HelixConfig.js
@@ -28,15 +28,20 @@ async function isFile(filePath) {
 }
 
 class HelixConfig {
-  constructor(config = {}) {
+  constructor() {
     this._cwd = process.cwd();
     this._cfgPath = '';
     this._source = '';
-    this._cfg = config;
+    this._cfg = {};
     this._logger = console;
     this._version = '';
 
     this._strains = new Strains();
+  }
+
+  withJSON(obj) {
+    this._cfg = obj;
+    return this;
   }
 
   withSource(value) {

--- a/src/HelixConfig.js
+++ b/src/HelixConfig.js
@@ -28,11 +28,11 @@ async function isFile(filePath) {
 }
 
 class HelixConfig {
-  constructor() {
+  constructor(config = {}) {
     this._cwd = process.cwd();
     this._cfgPath = '';
     this._source = '';
-    this._cfg = {};
+    this._cfg = config;
     this._logger = console;
     this._version = '';
 
@@ -100,7 +100,7 @@ class HelixConfig {
     if (this._source.indexOf('\t') >= 0) {
       throw Error('Tabs not allowed in helix-config.yaml');
     }
-    this._cfg = yaml.safeLoad(this._source) || {};
+    this._cfg = yaml.safeLoad(this._source) || this._cfg;
   }
 
   async validate() {

--- a/src/Origin.js
+++ b/src/Origin.js
@@ -28,7 +28,11 @@ class Origin {
       this._SSLCertHostname = cfg.ssl_cert_hostname || this._hostname;
       this._maxConn = cfg.max_conn || 200;
       this._useSSL = !(cfg.use_ssl === false);
-      this._port = cfg.port || this._useSSL ? 443 : 80;
+      if (cfg.port && Number.parseInt(cfg.port, 10) > 0) {
+        this._port = cfg.port;
+      } else {
+        this._port = this._useSSL ? 443 : 80;
+      }
     } else if (cfg && URI.parse(cfg).scheme) {
       const backenduri = URI.parse(cfg);
       this._hostname = backenduri.host;
@@ -72,7 +76,7 @@ class Origin {
   }
 
   get connectTimeout() {
-    return this._connectTimeout;
+    return Number.parseInt(this._connectTimeout, 10);
   }
 
   get name() {
@@ -80,7 +84,7 @@ class Origin {
   }
 
   get port() {
-    return this._port;
+    return Number.parseInt(this._port, 10);
   }
 
   get betweenBytesTimeout() {

--- a/src/Strain.js
+++ b/src/Strain.js
@@ -176,6 +176,8 @@ class Strain {
     if (this._url) {
       this._urls.add(this._url);
     }
+
+    this._params = Array.isArray(cfg.params) ? cfg.params : [];
   }
 
   clone() {
@@ -255,6 +257,10 @@ class Strain {
     this._package = value;
   }
 
+  get params() {
+    return this._params;
+  }
+
   get condition() {
     return this._condition;
   }
@@ -305,6 +311,9 @@ class Strain {
     };
     if (this.url) {
       json.url = this.url;
+    }
+    if (this.params.length > 0) {
+      json.params = this.params;
     }
     if (this.isProxy()) {
       return Object.assign({

--- a/src/Strain.js
+++ b/src/Strain.js
@@ -298,13 +298,14 @@ class Strain {
    */
   toJSON(opts) {
     const json = {
-      name: this.name,
       sticky: this.sticky,
       condition: this.condition,
       perf: this.perf.toJSON(opts),
-      url: this.url,
       urls: this.urls,
     };
+    if (this.url) {
+      json.url = this.url;
+    }
     if (this.isProxy()) {
       return Object.assign({
         origin: this.origin.toJSON(opts),

--- a/src/schemas/giturl.schema.json
+++ b/src/schemas/giturl.schema.json
@@ -26,7 +26,7 @@
     "hostname": {
       "description": "The hostname without port",
       "type":"string",
-      "pattern": "hostname"
+      "format": "hostname"
     },
     "host": {
       "description": "The hostname with port",
@@ -34,7 +34,7 @@
     },
     "port": {
       "description": "The port to access the Git Repository",
-      "type":"integer"
+      "type":["integer", "string"]
     },
     "owner": {
       "description": "The owner or username that the repository belongs to",

--- a/src/schemas/giturl.schema.json
+++ b/src/schemas/giturl.schema.json
@@ -28,6 +28,10 @@
       "type":"string",
       "pattern": "hostname"
     },
+    "host": {
+      "description": "The hostname with port",
+      "type":"string"
+    },
     "port": {
       "description": "The port to access the Git Repository",
       "type":"integer"

--- a/src/schemas/origin.schema.json
+++ b/src/schemas/origin.schema.json
@@ -70,17 +70,5 @@
       "type": "boolean",
       "description": ""
     }
-  },
-  "oneOf": [
-    {
-      "required": [
-        "hostname"
-      ]
-    },
-    {
-      "required": [
-        "address"
-      ]
-    }
-  ]
+  }
 }

--- a/src/schemas/proxystrain.schema.json
+++ b/src/schemas/proxystrain.schema.json
@@ -51,6 +51,13 @@
     },
     "perf": {
       "$ref": "https://ns.adobe.com/helix/shared/performance"
+    },
+    "params": {
+      "description": "A whitelist (using globbing language) of URL parameters. Note: every parameter is a potential cache killer.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": [

--- a/src/schemas/proxystrain.schema.json
+++ b/src/schemas/proxystrain.schema.json
@@ -20,7 +20,7 @@
   "properties": {
     "origin": {
       "description": "Origin backend for proxy strains.",
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "format": "uri"

--- a/src/schemas/runtimestrain.schema.json
+++ b/src/schemas/runtimestrain.schema.json
@@ -45,7 +45,7 @@
           "type": "string",
           "format": "uri"
         },
-        {"$ref": "https://ns.adobe.com/helix/shared/giturl"}
+        {"$ref": "https://ns.adobe.com/helix/shared/staticgiturl"}
       ]
     },
     "directoryIndex": {

--- a/src/schemas/runtimestrain.schema.json
+++ b/src/schemas/runtimestrain.schema.json
@@ -80,6 +80,13 @@
     },
     "perf": {
       "$ref": "https://ns.adobe.com/helix/shared/performance"
+    },
+    "params": {
+      "description": "A whitelist (using globbing language) of URL parameters. Note: every parameter is a potential cache killer.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": [

--- a/src/schemas/staticgiturl.schema.json
+++ b/src/schemas/staticgiturl.schema.json
@@ -1,0 +1,80 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe. All rights reserved.",
+    "This file is licensed to you under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at http://www.apache.org/licenses/LICENSE-2.0",
+    "",
+    "Unless required by applicable law or agreed to in writing, software distributed under",
+    "the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS",
+    "OF ANY KIND, either express or implied. See the License for the specific language",
+    "governing permissions and limitations under the License."
+  ],
+  "$id": "https://ns.adobe.com/helix/shared/staticgiturl",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Git URL",
+  "type": "object",
+  "meta:status": "stabilizing",
+  "description": "Representation of the fragments of a Git URL",
+  "additionalProperties": false,
+  "properties": {
+    "protocol": {
+      "description": "The protocol to access the Git repository",
+      "enum": ["https", "http", "ssh"],
+      "type":"string"
+    },
+    "hostname": {
+      "description": "The hostname without port",
+      "type":"string",
+      "format": "hostname"
+    },
+    "host": {
+      "description": "The hostname with port",
+      "type":"string"
+    },
+    "port": {
+      "description": "The port to access the Git Repository",
+      "type":["integer", "string"]
+    },
+    "owner": {
+      "description": "The owner or username that the repository belongs to",
+      "type":"string"
+    },
+    "path": {
+      "description": "The path within the repository",
+      "type":"string"
+    },
+    "repo": {
+      "description": "The repository name",
+      "type":"string"
+    },
+    "ref": {
+      "description": "The branch, tag, or sha of the tree in the repository to use",
+      "default": "master",
+      "type":"string"
+    },
+    "allow": {
+      "description": "List of white listed paths",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "deny": {
+      "description": "List of white listed paths",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "magic": {
+      "type": "boolean",
+      "description": "Deprecated: Enable server-side asset processing."
+    }
+  },
+  "required": [
+    "owner",
+    "repo",
+    "ref"
+  ]
+}

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -113,9 +113,9 @@ describe('Helix Config Loading', () => {
       .withSource(source)
       .init();
     const cfg2 = await new HelixConfig()
-       .withJSON(cfg1.toJSON())
-       .init();
-    assert.equal(cfg1.toJSON(), cfg2.toJSON());
+      .withJSON(cfg1.toJSON())
+      .init();
+    assert.deepEqual(cfg1.toJSON(), cfg2.toJSON());
   });
 });
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -112,7 +112,9 @@ describe('Helix Config Loading', () => {
     const cfg1 = await new HelixConfig()
       .withSource(source)
       .init();
-    const cfg2 = await new HelixConfig(cfg1.toJSON()).init();
+    const cfg2 = await new HelixConfig()
+       .withJSON(cfg1.toJSON())
+       .init();
     assert.equal(cfg1.toJSON(), cfg2.toJSON());
   });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -106,6 +106,15 @@ describe('Helix Config Loading', () => {
       .init();
     assert.equal(cfg.configPath, path.resolve(SPEC_ROOT, 'helix-config.yaml'));
   });
+
+  it('can be constructed with JSON object', async () => {
+    const source = await fs.readFile(path.resolve(SPEC_ROOT, 'full.yaml'), 'utf-8');
+    const cfg1 = await new HelixConfig()
+      .withSource(source)
+      .init();
+    const cfg2 = await new HelixConfig(cfg1.toJSON()).init();
+    assert.equal(cfg1.toJSON(), cfg2.toJSON());
+  });
 });
 
 describe('Helix Config Serializing', () => {

--- a/test/specs/configs/full.json
+++ b/test/specs/configs/full.json
@@ -182,7 +182,10 @@
         "repo": "project-helix.io"
       },
       "sticky": true,
-
+      "params": [
+        "search",
+        "lang"
+      ],
       "urls": []
     },
     "proxy": {
@@ -208,7 +211,10 @@
         "location": ""
       },
       "sticky": true,
-
+      "params": [
+        "search",
+        "api*"
+      ],
       "urls": []
     },
     "proxy-detailed": {

--- a/test/specs/configs/full.json
+++ b/test/specs/configs/full.json
@@ -24,7 +24,6 @@
         "repo": "project-helix.io"
       },
       "directoryIndex": "index.html",
-      "name": "adhoc",
       "perf": {
         "connection": "",
         "device": "",
@@ -44,7 +43,7 @@
         "repo": "project-helix.io"
       },
       "sticky": false,
-      "url": "",
+
       "urls": [],
       "package": "75f29aa936bfc2b84bde5ac0ee4afbf824b1391e-dirty"
     },
@@ -71,7 +70,6 @@
         "repo": "helix-cli"
       },
       "directoryIndex": "readme.html",
-      "name": "client",
       "package": "",
       "perf": {
         "connection": "",
@@ -92,7 +90,7 @@
         "repo": "project-helix.io"
       },
       "sticky": false,
-      "url": "",
+
       "urls": []
     },
     "default": {
@@ -118,7 +116,6 @@
         "repo": "project-helix.io"
       },
       "directoryIndex": "index.html",
-      "name": "default",
       "package": "",
       "perf": {
         "connection": "",
@@ -139,7 +136,7 @@
         "repo": "project-helix.io"
       },
       "sticky": false,
-      "url": "",
+
       "urls": []
     },
     "pipeline": {
@@ -165,7 +162,6 @@
         "repo": "hypermedia-pipeline"
       },
       "directoryIndex": "index.html",
-      "name": "pipeline",
       "package": "",
       "perf": {
         "connection": "",
@@ -186,12 +182,11 @@
         "repo": "project-helix.io"
       },
       "sticky": true,
-      "url": "",
+
       "urls": []
     },
     "proxy": {
       "condition": "req.http.host == \"proxy.project-helix.io\"",
-      "name": "proxy",
       "origin": {
         "address": "www.adobe.io",
         "between_bytes_timeout": 10000,
@@ -213,12 +208,11 @@
         "location": ""
       },
       "sticky": true,
-      "url": "",
+
       "urls": []
     },
     "proxy-detailed": {
       "condition": "",
-      "name": "proxy-detailed",
       "origin": {
         "address": "192.168.0.1",
         "between_bytes_timeout": 10000,
@@ -240,7 +234,7 @@
         "location": ""
       },
       "sticky": false,
-      "url": "",
+
       "urls": []
     }
   }

--- a/test/specs/configs/full.yaml
+++ b/test/specs/configs/full.yaml
@@ -42,6 +42,9 @@ strains:
   pipeline:
     <<: *basestrain
     condition: req.http.host == "pipeline.project-helix.io"
+    params:
+      - search
+      - lang
     content:
       repo: hypermedia-pipeline
       ref: master
@@ -53,6 +56,9 @@ strains:
   proxy:
     origin: https://www.adobe.io/
     condition: req.http.host == "proxy.project-helix.io"
+    params:
+      - search
+      - api*
     sticky: true
 
   proxy-detailed:

--- a/test/specs/configs/perf.json
+++ b/test/specs/configs/perf.json
@@ -23,7 +23,6 @@
         "repo": "project-helix.io"
       },
       "directoryIndex": "index.html",
-      "name": "client",
       "package": "",
       "perf": {
         "connection": "LTE",
@@ -44,7 +43,7 @@
         "repo": "project-helix.io"
       },
       "sticky": false,
-      "url": "",
+
       "urls": []
     },
     "default": {
@@ -70,7 +69,6 @@
         "repo": "project-helix.io"
       },
       "directoryIndex": "index.html",
-      "name": "default",
       "package": "",
       "perf": {
         "connection": "",
@@ -91,7 +89,7 @@
         "repo": "project-helix.io"
       },
       "sticky": false,
-      "url": "",
+
       "urls": []
     }
   },

--- a/test/specs/configs/urls.json
+++ b/test/specs/configs/urls.json
@@ -24,7 +24,6 @@
         "repo": "helix-cli"
       },
       "directoryIndex": "readme.html",
-      "name": "client",
       "package": "",
       "perf": {
         "connection": "",
@@ -75,7 +74,6 @@
         "repo": "project-helix.io"
       },
       "directoryIndex": "index.html",
-      "name": "default",
       "package": "",
       "perf": {
         "connection": "",
@@ -96,7 +94,6 @@
         "repo": "project-helix.io"
       },
       "sticky": false,
-      "url": "",
       "urls": [
         "https://www.project-helix.io/index.html"
       ]
@@ -124,7 +121,6 @@
         "repo": "hypermedia-pipeline"
       },
       "directoryIndex": "index.html",
-      "name": "pipeline",
       "package": "",
       "perf": {
         "connection": "",
@@ -152,7 +148,6 @@
     },
     "proxy": {
       "condition": "",
-      "name": "proxy",
       "origin": {
         "address": "www.adobe.io",
         "between_bytes_timeout": 10000,
@@ -181,7 +176,6 @@
     },
     "proxy-detailed": {
       "condition": "",
-      "name": "proxy-detailed",
       "origin": {
         "address": "192.168.0.1",
         "between_bytes_timeout": 10000,
@@ -203,7 +197,6 @@
         "location": ""
       },
       "sticky": false,
-      "url": "",
       "urls": []
     }
   }


### PR DESCRIPTION
Adds add `fromJSON` method to initialize a Helix Config from another HelixConfig's `.toJSON` output.

I had to adjust some of the schemas and some of the output to make it roundtripable.