### PR TITLE
feat(strains): Add support for Redirect rules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 * [Git URL](./staticgiturl.schema.md) – `https://ns.adobe.com/helix/shared/staticgiturl` (Stabilizing)
 * [Origin](./origin.schema.md) – `https://ns.adobe.com/helix/shared/origin` (Stabilizing)
 * [Proxy Strain](./proxystrain.schema.md) – `https://ns.adobe.com/helix/shared/proxystrain` (Stabilizing)
+* [Redirect Rule](./redirectrule.schema.md) – `https://ns.adobe.com/helix/shared/redirectrule` (Stabilizing)
 * [Runtime Strain](./performance.schema.md) – `https://ns.adobe.com/helix/shared/performance` (Stabilizing)
 * [Runtime Strain](./runtimestrain.schema.md) – `https://ns.adobe.com/helix/shared/runtimestrain` (Stabilizing)
 * [Strains](./strains.schema.md) – `https://ns.adobe.com/helix/shared/strains` (Stabilizing)

--- a/docs/proxystrain.schema.json
+++ b/docs/proxystrain.schema.json
@@ -60,6 +60,13 @@
             "items": {
                 "type": "string"
             }
+        },
+        "redirects": {
+            "type": "array",
+            "description": "The redirect rules that should be applied to this strain",
+            "items": {
+                "$ref": "https://ns.adobe.com/helix/shared/redirectrule"
+            }
         }
     },
     "required": [

--- a/docs/proxystrain.schema.md
+++ b/docs/proxystrain.schema.md
@@ -24,6 +24,7 @@ A strain is a combination of code and content that enables the creation of a dig
 | [origin](#origin) | complex | **Required** | Proxy Strain (this schema) |
 | [params](#params) | `string[]` | Optional | Proxy Strain (this schema) |
 | [perf](#perf) | Runtime Strain | Optional | Proxy Strain (this schema) |
+| [redirects](#redirects) | Redirect Rule | Optional | Proxy Strain (this schema) |
 | [sticky](#sticky) | `boolean` | Optional | Proxy Strain (this schema) |
 | [url](#url) | `string` | Optional | Proxy Strain (this schema) |
 | [urls](#urls) | `string[]` | Optional | Proxy Strain (this schema) |
@@ -124,6 +125,31 @@ All items must be of the type:
 
 
 * [Runtime Strain](performance.schema.md) – `https://ns.adobe.com/helix/shared/performance`
+
+
+
+
+
+## redirects
+
+The redirect rules that should be applied to this strain
+
+`redirects`
+
+* is optional
+* type: Redirect Rule
+* defined in this schema
+
+### redirects Type
+
+
+Array type: Redirect Rule
+
+All items must be of the type:
+* [Redirect Rule](redirectrule.schema.md) – `https://ns.adobe.com/helix/shared/redirectrule`
+
+
+
 
 
 

--- a/docs/redirectrule.schema.json
+++ b/docs/redirectrule.schema.json
@@ -1,0 +1,38 @@
+{
+    "meta:license": [
+        "Copyright 2019 Adobe. All rights reserved.",
+        "This file is licensed to you under the Apache License, Version 2.0 (the \"License\");",
+        "you may not use this file except in compliance with the License. You may obtain a copy",
+        "of the License at http://www.apache.org/licenses/LICENSE-2.0",
+        "",
+        "Unless required by applicable law or agreed to in writing, software distributed under",
+        "the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS",
+        "OF ANY KIND, either express or implied. See the License for the specific language",
+        "governing permissions and limitations under the License."
+    ],
+    "$id": "https://ns.adobe.com/helix/shared/redirectrule",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Redirect Rule",
+    "type": "object",
+    "meta:status": "stabilizing",
+    "description": "A strain is a combination of code and content that enables the creation of a digital experience. Strains can be used to create language variants of websites, A/B tests, personalization, or to aggregate content from multiple sources",
+    "additionalProperties": false,
+    "properties": {
+        "from": {
+            "type": "string",
+            "description": "A URL path or regular expression to match the path of a URL. It can contain capture groups that can be used in `to`.",
+            "examples": [
+                "/old",
+                "/old/(.*)\\.php$"
+            ]
+        },
+        "to": {
+            "type": "string",
+            "description": "A replacement string that replaces matched URLs found in `from`.",
+            "examples": [
+                "/new",
+                "/new/$1.html"
+            ]
+        }
+    }
+}

--- a/docs/redirectrule.schema.md
+++ b/docs/redirectrule.schema.md
@@ -1,0 +1,83 @@
+
+# Redirect Rule Schema
+
+```
+https://ns.adobe.com/helix/shared/redirectrule
+```
+
+A strain is a combination of code and content that enables the creation of a digital experience. Strains can be used to create language variants of websites, A/B tests, personalization, or to aggregate content from multiple sources
+
+| Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------|------------|--------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Stabilizing | No | Forbidden | Forbidden | [redirectrule.schema.json](redirectrule.schema.json) |
+
+# Redirect Rule Properties
+
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [from](#from) | `string` | Optional | Redirect Rule (this schema) |
+| [to](#to) | `string` | Optional | Redirect Rule (this schema) |
+
+## from
+
+A URL path or regular expression to match the path of a URL. It can contain capture groups that can be used in `to`.
+
+`from`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### from Type
+
+
+`string`
+
+
+
+
+
+
+### from Examples
+
+```json
+"/old"
+```
+
+```json
+"/old/(.*)\\.php$"
+```
+
+
+
+## to
+
+A replacement string that replaces matched URLs found in `from`.
+
+`to`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### to Type
+
+
+`string`
+
+
+
+
+
+
+### to Examples
+
+```json
+"/new"
+```
+
+```json
+"/new/$1.html"
+```
+
+

--- a/docs/runtimestrain.schema.json
+++ b/docs/runtimestrain.schema.json
@@ -93,6 +93,13 @@
             "items": {
                 "type": "string"
             }
+        },
+        "redirects": {
+            "type": "array",
+            "description": "The redirect rules that should be applied to this strain",
+            "items": {
+                "$ref": "https://ns.adobe.com/helix/shared/redirectrule"
+            }
         }
     },
     "required": [

--- a/docs/runtimestrain.schema.md
+++ b/docs/runtimestrain.schema.md
@@ -27,6 +27,7 @@ A runtime strain is a combination of code and content that enables the creation 
 | [package](#package) | `string` | Optional |  | Runtime Strain (this schema) |
 | [params](#params) | `string[]` | Optional |  | Runtime Strain (this schema) |
 | [perf](#perf) | Runtime Strain | Optional |  | Runtime Strain (this schema) |
+| [redirects](#redirects) | Redirect Rule | Optional |  | Runtime Strain (this schema) |
 | [static](#static) | complex | **Required** |  | Runtime Strain (this schema) |
 | [sticky](#sticky) | `boolean` | Optional |  | Runtime Strain (this schema) |
 | [url](#url) | `string` | Optional |  | Runtime Strain (this schema) |
@@ -206,6 +207,31 @@ All items must be of the type:
 
 
 * [Runtime Strain](performance.schema.md) – `https://ns.adobe.com/helix/shared/performance`
+
+
+
+
+
+## redirects
+
+The redirect rules that should be applied to this strain
+
+`redirects`
+
+* is optional
+* type: Redirect Rule
+* defined in this schema
+
+### redirects Type
+
+
+Array type: Redirect Rule
+
+All items must be of the type:
+* [Redirect Rule](redirectrule.schema.md) – `https://ns.adobe.com/helix/shared/redirectrule`
+
+
+
 
 
 

--- a/src/ConfigValidator.js
+++ b/src/ConfigValidator.js
@@ -21,6 +21,7 @@ const schemas = [
   require('./schemas/staticgiturl.schema.json'),
   require('./schemas/origin.schema.json'),
   require('./schemas/performance.schema.json'),
+  require('./schemas/redirectrule.schema.json'),
   /* eslint-enable global-require */
 ];
 

--- a/src/Redirect.js
+++ b/src/Redirect.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Defines a redirect rule
+ */
+class Redirect {
+  constructor(cfg) {
+    this._from = new RegExp(cfg.from);
+    this._to = cfg.to;
+  }
+
+  get from() {
+    return this._from.source;
+  }
+
+  get to() {
+    return this._to;
+  }
+
+  toJSON() {
+    return {
+      from: this.from,
+      to: this.to,
+    };
+  }
+}
+
+module.exports = Redirect;

--- a/src/Strain.js
+++ b/src/Strain.js
@@ -20,6 +20,7 @@ const GitUrl = require('./GitUrl.js');
 const Origin = require('./Origin.js');
 const Static = require('./Static.js');
 const Performance = require('./Performance.js');
+const Redirect = require('./Redirect.js');
 const utils = require('./utils.js');
 
 /**
@@ -53,6 +54,8 @@ class Strain {
     // assume the strain to be sticky when there is a condition
     this._sticky = cfg.sticky === undefined ? this._condition !== '' : !!cfg.sticky;
 
+    this._redirects = (Array.isArray(cfg.redirects) ? cfg.redirects : []).map(r => new Redirect(r));
+
     // todo: I assume this will go into the new condition language
     // todo: if not, I would only have 1 property `url` that can be single or multi valued
     this._url = cfg.url ? URI.normalize(cfg.url) : '';
@@ -76,6 +79,7 @@ class Strain {
       'url',
       'urls',
       'params',
+      'redirects',
     ]);
   }
 
@@ -197,6 +201,10 @@ class Strain {
     return this._origin !== null;
   }
 
+  get redirects() {
+    return this._redirects;
+  }
+
   /**
    * JSON Serialization of a Strain
    * @typedef Strain~JSON
@@ -226,6 +234,9 @@ class Strain {
     }
     if (this.params.length > 0) {
       json.params = this.params;
+    }
+    if (this.redirects.length > 0) {
+      json.redirects = this.redirects.map(r => r.toJSON());
     }
     if (this.isProxy()) {
       return Object.assign({

--- a/src/schemas/proxystrain.schema.json
+++ b/src/schemas/proxystrain.schema.json
@@ -58,6 +58,13 @@
       "items": {
         "type": "string"
       }
+    },
+    "redirects": {
+      "type": "array",
+      "description": "The redirect rules that should be applied to this strain",
+      "items": {
+        "$ref": "https://ns.adobe.com/helix/shared/redirectrule"
+      }
     }
   },
   "required": [

--- a/src/schemas/redirectrule.schema.json
+++ b/src/schemas/redirectrule.schema.json
@@ -1,0 +1,38 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe. All rights reserved.",
+    "This file is licensed to you under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at http://www.apache.org/licenses/LICENSE-2.0",
+    "",
+    "Unless required by applicable law or agreed to in writing, software distributed under",
+    "the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS",
+    "OF ANY KIND, either express or implied. See the License for the specific language",
+    "governing permissions and limitations under the License."
+  ],
+  "$id": "https://ns.adobe.com/helix/shared/redirectrule",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Redirect Rule",
+  "type": "object",
+  "meta:status": "stabilizing",
+  "description": "A strain is a combination of code and content that enables the creation of a digital experience. Strains can be used to create language variants of websites, A/B tests, personalization, or to aggregate content from multiple sources",
+  "additionalProperties": false,
+  "properties": {
+    "from": {
+      "type": "string",
+      "description": "A URL path or regular expression to match the path of a URL. It can contain capture groups that can be used in `to`.",
+      "examples": [
+        "/old",
+        "/old/(.*)\\.php$"
+      ]
+    },
+    "to": {
+      "type": "string",
+      "description": "A replacement string that replaces matched URLs found in `from`.",
+      "examples": [
+        "/new",
+        "/new/$1.html"
+      ]
+    }
+  }
+}

--- a/src/schemas/runtimestrain.schema.json
+++ b/src/schemas/runtimestrain.schema.json
@@ -87,6 +87,13 @@
       "items": {
         "type": "string"
       }
+    },
+    "redirects": {
+      "type": "array",
+      "description": "The redirect rules that should be applied to this strain",
+      "items": {
+        "$ref": "https://ns.adobe.com/helix/shared/redirectrule"
+      }
     }
   },
   "required": [

--- a/test/redirects.test.js
+++ b/test/redirects.test.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const { AssertionError } = require('assert');
+const Redirect = require('../src/Redirect');
+
+describe('Redirect test', () => {
+  it('Redirects cannot be created without arguments', () => {
+    try {
+      // eslint-disable-next-line no-new
+      new Redirect();
+      assert.fail('expected exception not thrown'); // this throws an AssertionError
+    } catch (e) { // this catches all errors, those thrown by the function under test
+      // and those thrown by assert.fail
+      if (e instanceof AssertionError) {
+        // bubble up the assertion error
+        throw e;
+      }
+    }
+  });
+
+  it('Redirects cannot be created from invalid regex', () => {
+    try {
+      // eslint-disable-next-line no-new
+      new Redirect({
+        from: '/(',
+        to: '/invalid',
+      });
+      assert.fail('expected exception not thrown'); // this throws an AssertionError
+    } catch (e) { // this catches all errors, those thrown by the function under test
+      // and those thrown by assert.fail
+      if (e instanceof AssertionError) {
+        // bubble up the assertion error
+        throw e;
+      }
+    }
+  });
+
+  it('Redirects work', () => {
+    const before = {
+      from: '\\/foo',
+      to: '/bar',
+    };
+
+    const r = new Redirect(before);
+
+    assert.equal(r.from, before.from);
+    assert.equal(r.to, before.to);
+    assert.deepStrictEqual(r.toJSON(), before);
+  });
+});

--- a/test/specs/configs/full.json
+++ b/test/specs/configs/full.json
@@ -140,6 +140,12 @@
       "urls": []
     },
     "pipeline": {
+      "redirects": [
+        {
+          "from": "(.*)\\.php",
+          "to": "$1.html"
+        }
+      ],
       "code": {
         "host": "github.com",
         "hostname": "github.com",
@@ -240,7 +246,12 @@
         "location": ""
       },
       "sticky": false,
-
+      "redirects": [
+        {
+          "from": "\\/old",
+          "to": "/new"
+        }
+      ],
       "urls": []
     }
   }

--- a/test/specs/configs/full.json
+++ b/test/specs/configs/full.json
@@ -144,6 +144,10 @@
         {
           "from": "(.*)\\.php",
           "to": "$1.html"
+        },
+        {
+          "from": "\\/content\\/dam\\/(.*)$",
+          "to": "/htdocs/$1"
         }
       ],
       "code": {

--- a/test/specs/configs/full.yaml
+++ b/test/specs/configs/full.yaml
@@ -54,6 +54,9 @@ strains:
     static:
       <<: *myrepo
       path: /www
+    redirects:
+      - from: (.*)\.php
+        to: $1.html
 
   proxy:
     origin: https://www.adobe.io/
@@ -64,6 +67,9 @@ strains:
     sticky: true
 
   proxy-detailed:
+    redirects:
+      - from: /old
+        to: /new
     origin:
       address: 192.168.0.1
       name: publish

--- a/test/specs/configs/full.yaml
+++ b/test/specs/configs/full.yaml
@@ -57,6 +57,8 @@ strains:
     redirects:
       - from: (.*)\.php
         to: $1.html
+      - from: /content/dam/(.*)$
+        to: /htdocs/$1
 
   proxy:
     origin: https://www.adobe.io/

--- a/test/strains.test.js
+++ b/test/strains.test.js
@@ -145,6 +145,27 @@ describe('Strains test', () => {
     assert.deepEqual(strain.static.ref, strain.static.url.ref);
   });
 
+  it('redirects can be read', () => {
+    const strain = new Strain('test', {
+      code: 'https://github.com/adobe/project-helix.io.git',
+      content: 'https://github.com/adobe/project-helix.io.git',
+      static: 'https://github.com/adobe/project-helix.io.git',
+      redirects: [
+        {
+          from: '/foo',
+          to: '/bar',
+        },
+        {
+          from: '/baz',
+          to: '/qwe',
+        },
+      ],
+    });
+
+    assert.ok(Array.isArray(strain.redirects));
+    assert.equal(strain.redirects.length, 2);
+  });
+
   it('urls can be changed after initialization', () => {
     const gitUrl = 'https://github.com/adobe/helix-shared.git#master';
     const newGitUrl = new GitUrl('https://github.com/adobe/project-helix.io.git#dev');


### PR DESCRIPTION
Enables the definition of a list of `redirects` for a strain. Each item in the list is a a pair of
`from` (regex) and `to` (replacement pattern) tuples

Fixes #59

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
