### PR TITLE
fix(schema): Add schema for missing performance metrics

### DIFF
--- a/docs/performance.schema.json
+++ b/docs/performance.schema.json
@@ -29,6 +29,138 @@
         "connection": {
             "description": "Testing connection",
             "type": "string"
+        },
+        "lighthouse-seo-score": {
+            "type": "number",
+            "description": "Lighthouse SEO Score"
+        },
+        "lighthouse-best-practices-score": {
+            "type": "number",
+            "description": "Lighthouse Best Practices Score"
+        },
+        "lighthouse-accessibility-score": {
+            "type": "number",
+            "description": "Lighthouse Accessibility Score"
+        },
+        "lighthouse-performance-score": {
+            "type": "number",
+            "description": "Lighthouse Performance Score"
+        },
+        "lighthouse-pwa-score": {
+            "type": "number",
+            "description": "Lighthouse Progressive Web App Score"
+        },
+        "js-parse-compile": {
+            "type": "number",
+            "description": "JS Parse & Compile"
+        },
+        "dom-size": {
+            "type": "number",
+            "description": "DOM Element Count"
+        },
+        "visually_complete_85": {
+            "type": "number",
+            "description": "85% Visually Complete"
+        },
+        "visually_complete": {
+            "type": "number",
+            "description": "Visually Complete"
+        },
+        "consistently-interactive": {
+            "type": "number",
+            "description": "Time to Interactive"
+        },
+        "first-interactive": {
+            "type": "number",
+            "description": "First CPU Idle"
+        },
+        "time-to-first-byte": {
+            "type": "number",
+            "description": "Time to First Byte"
+        },
+        "estimated-input-latency": {
+            "type": "number",
+            "description": "Estimated input latency"
+        },
+        "speed_index": {
+            "type": "number",
+            "description": "Speed Index"
+        },
+        "first-meaningful-paint": {
+            "type": "number",
+            "description": "First Meaningful Paint"
+        },
+        "first-contentful-paint": {
+            "type": "number",
+            "description": "First Contentful Paint"
+        },
+        "firstRender": {
+            "type": "number",
+            "description": "First Paint"
+        },
+        "image_body_size_in_bytes": {
+            "type": "number",
+            "description": "Total Image size in bytes"
+        },
+        "image_size_in_bytes": {
+            "type": "number",
+            "description": "Total Image transferred"
+        },
+        "font_body_size_in_bytes": {
+            "type": "number",
+            "description": "Total Webfont size in bytes"
+        },
+        "font_size_in_bytes": {
+            "type": "number",
+            "description": "Total Webfont transferred"
+        },
+        "js_body_size_in_bytes": {
+            "type": "number",
+            "description": "Total JavaScript size in bytes"
+        },
+        "js_size_in_bytes": {
+            "type": "number",
+            "description": "Total JavaScript Transferred"
+        },
+        "css_body_size_in_bytes": {
+            "type": "number",
+            "description": "Total CSS size in bytes"
+        },
+        "css_size_in_bytes": {
+            "type": "number",
+            "description": "Total CSS transferred"
+        },
+        "html_body_size_in_bytes": {
+            "type": "number",
+            "description": "Total HTML size in bytes"
+        },
+        "html_size_in_bytes": {
+            "type": "number",
+            "description": "Total HTML transferred"
+        },
+        "page_wait_timing": {
+            "type": "number",
+            "description": "Response time"
+        },
+        "page_size_in_bytes": {
+            "type": "number",
+            "description": "Total Page transferred"
+        },
+        "page_body_size_in_bytes": {
+            "type": "number",
+            "description": "Total Page size in bytes"
+        },
+        "asset_count": {
+            "type": "number",
+            "description": "Number of requests"
+        },
+        "onload": {
+            "type": "number",
+            "description": "onLoad"
+        },
+        "oncontentload": {
+            "type": "number",
+            "description": "onContentLoad"
         }
     }
 }

--- a/docs/performance.schema.md
+++ b/docs/performance.schema.md
@@ -15,9 +15,63 @@ Performance testing details.
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
+| [asset_count](#asset_count) | `number` | Optional | Runtime Strain (this schema) |
 | [connection](#connection) | `string` | Optional | Runtime Strain (this schema) |
+| [consistently-interactive](#consistently-interactive) | `number` | Optional | Runtime Strain (this schema) |
+| [css_body_size_in_bytes](#css_body_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [css_size_in_bytes](#css_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
 | [device](#device) | `string` | Optional | Runtime Strain (this schema) |
+| [dom-size](#dom-size) | `number` | Optional | Runtime Strain (this schema) |
+| [estimated-input-latency](#estimated-input-latency) | `number` | Optional | Runtime Strain (this schema) |
+| [first-contentful-paint](#first-contentful-paint) | `number` | Optional | Runtime Strain (this schema) |
+| [first-interactive](#first-interactive) | `number` | Optional | Runtime Strain (this schema) |
+| [first-meaningful-paint](#first-meaningful-paint) | `number` | Optional | Runtime Strain (this schema) |
+| [firstRender](#firstrender) | `number` | Optional | Runtime Strain (this schema) |
+| [font_body_size_in_bytes](#font_body_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [font_size_in_bytes](#font_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [html_body_size_in_bytes](#html_body_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [html_size_in_bytes](#html_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [image_body_size_in_bytes](#image_body_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [image_size_in_bytes](#image_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [js-parse-compile](#js-parse-compile) | `number` | Optional | Runtime Strain (this schema) |
+| [js_body_size_in_bytes](#js_body_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [js_size_in_bytes](#js_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [lighthouse-accessibility-score](#lighthouse-accessibility-score) | `number` | Optional | Runtime Strain (this schema) |
+| [lighthouse-best-practices-score](#lighthouse-best-practices-score) | `number` | Optional | Runtime Strain (this schema) |
+| [lighthouse-performance-score](#lighthouse-performance-score) | `number` | Optional | Runtime Strain (this schema) |
+| [lighthouse-pwa-score](#lighthouse-pwa-score) | `number` | Optional | Runtime Strain (this schema) |
+| [lighthouse-seo-score](#lighthouse-seo-score) | `number` | Optional | Runtime Strain (this schema) |
 | [location](#location) | `string` | Optional | Runtime Strain (this schema) |
+| [oncontentload](#oncontentload) | `number` | Optional | Runtime Strain (this schema) |
+| [onload](#onload) | `number` | Optional | Runtime Strain (this schema) |
+| [page_body_size_in_bytes](#page_body_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [page_size_in_bytes](#page_size_in_bytes) | `number` | Optional | Runtime Strain (this schema) |
+| [page_wait_timing](#page_wait_timing) | `number` | Optional | Runtime Strain (this schema) |
+| [speed_index](#speed_index) | `number` | Optional | Runtime Strain (this schema) |
+| [time-to-first-byte](#time-to-first-byte) | `number` | Optional | Runtime Strain (this schema) |
+| [visually_complete](#visually_complete) | `number` | Optional | Runtime Strain (this schema) |
+| [visually_complete_85](#visually_complete_85) | `number` | Optional | Runtime Strain (this schema) |
+
+## asset_count
+
+Number of requests
+
+`asset_count`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### asset_count Type
+
+
+`number`
+
+
+
+
+
+
 
 ## connection
 
@@ -33,6 +87,69 @@ Testing connection
 
 
 `string`
+
+
+
+
+
+
+
+## consistently-interactive
+
+Time to Interactive
+
+`consistently-interactive`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### consistently-interactive Type
+
+
+`number`
+
+
+
+
+
+
+
+## css_body_size_in_bytes
+
+Total CSS size in bytes
+
+`css_body_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### css_body_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## css_size_in_bytes
+
+Total CSS transferred
+
+`css_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### css_size_in_bytes Type
+
+
+`number`
 
 
 
@@ -61,6 +178,426 @@ Testing device
 
 
 
+## dom-size
+
+DOM Element Count
+
+`dom-size`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### dom-size Type
+
+
+`number`
+
+
+
+
+
+
+
+## estimated-input-latency
+
+Estimated input latency
+
+`estimated-input-latency`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### estimated-input-latency Type
+
+
+`number`
+
+
+
+
+
+
+
+## first-contentful-paint
+
+First Contentful Paint
+
+`first-contentful-paint`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### first-contentful-paint Type
+
+
+`number`
+
+
+
+
+
+
+
+## first-interactive
+
+First CPU Idle
+
+`first-interactive`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### first-interactive Type
+
+
+`number`
+
+
+
+
+
+
+
+## first-meaningful-paint
+
+First Meaningful Paint
+
+`first-meaningful-paint`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### first-meaningful-paint Type
+
+
+`number`
+
+
+
+
+
+
+
+## firstRender
+
+First Paint
+
+`firstRender`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### firstRender Type
+
+
+`number`
+
+
+
+
+
+
+
+## font_body_size_in_bytes
+
+Total Webfont size in bytes
+
+`font_body_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### font_body_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## font_size_in_bytes
+
+Total Webfont transferred
+
+`font_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### font_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## html_body_size_in_bytes
+
+Total HTML size in bytes
+
+`html_body_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### html_body_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## html_size_in_bytes
+
+Total HTML transferred
+
+`html_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### html_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## image_body_size_in_bytes
+
+Total Image size in bytes
+
+`image_body_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### image_body_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## image_size_in_bytes
+
+Total Image transferred
+
+`image_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### image_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## js-parse-compile
+
+JS Parse & Compile
+
+`js-parse-compile`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### js-parse-compile Type
+
+
+`number`
+
+
+
+
+
+
+
+## js_body_size_in_bytes
+
+Total JavaScript size in bytes
+
+`js_body_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### js_body_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## js_size_in_bytes
+
+Total JavaScript Transferred
+
+`js_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### js_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## lighthouse-accessibility-score
+
+Lighthouse Accessibility Score
+
+`lighthouse-accessibility-score`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### lighthouse-accessibility-score Type
+
+
+`number`
+
+
+
+
+
+
+
+## lighthouse-best-practices-score
+
+Lighthouse Best Practices Score
+
+`lighthouse-best-practices-score`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### lighthouse-best-practices-score Type
+
+
+`number`
+
+
+
+
+
+
+
+## lighthouse-performance-score
+
+Lighthouse Performance Score
+
+`lighthouse-performance-score`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### lighthouse-performance-score Type
+
+
+`number`
+
+
+
+
+
+
+
+## lighthouse-pwa-score
+
+Lighthouse Progressive Web App Score
+
+`lighthouse-pwa-score`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### lighthouse-pwa-score Type
+
+
+`number`
+
+
+
+
+
+
+
+## lighthouse-seo-score
+
+Lighthouse SEO Score
+
+`lighthouse-seo-score`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### lighthouse-seo-score Type
+
+
+`number`
+
+
+
+
+
+
+
 ## location
 
 Testing location
@@ -75,6 +612,195 @@ Testing location
 
 
 `string`
+
+
+
+
+
+
+
+## oncontentload
+
+onContentLoad
+
+`oncontentload`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### oncontentload Type
+
+
+`number`
+
+
+
+
+
+
+
+## onload
+
+onLoad
+
+`onload`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### onload Type
+
+
+`number`
+
+
+
+
+
+
+
+## page_body_size_in_bytes
+
+Total Page size in bytes
+
+`page_body_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### page_body_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## page_size_in_bytes
+
+Total Page transferred
+
+`page_size_in_bytes`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### page_size_in_bytes Type
+
+
+`number`
+
+
+
+
+
+
+
+## page_wait_timing
+
+Response time
+
+`page_wait_timing`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### page_wait_timing Type
+
+
+`number`
+
+
+
+
+
+
+
+## speed_index
+
+Speed Index
+
+`speed_index`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### speed_index Type
+
+
+`number`
+
+
+
+
+
+
+
+## time-to-first-byte
+
+Time to First Byte
+
+`time-to-first-byte`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### time-to-first-byte Type
+
+
+`number`
+
+
+
+
+
+
+
+## visually_complete
+
+Visually Complete
+
+`visually_complete`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### visually_complete Type
+
+
+`number`
+
+
+
+
+
+
+
+## visually_complete_85
+
+85% Visually Complete
+
+`visually_complete_85`
+
+* is optional
+* type: `number`
+* defined in this schema
+
+### visually_complete_85 Type
+
+
+`number`
 
 
 

--- a/src/schemas/performance.schema.json
+++ b/src/schemas/performance.schema.json
@@ -29,6 +29,134 @@
     "connection": {
       "description": "Testing connection",
       "type": "string"
-    }
+    },
+    "lighthouse-seo-score": {
+      "type": "number",
+      "description": "Lighthouse SEO Score"
+    },
+  
+    "lighthouse-best-practices-score": {
+      "type": "number",
+      "description": "Lighthouse Best Practices Score"
+    },
+  
+    "lighthouse-accessibility-score": {
+      "type": "number",
+      "description": "Lighthouse Accessibility Score"
+    },
+  
+    "lighthouse-performance-score": {
+      "type": "number",
+      "description": "Lighthouse Performance Score"
+    },
+  
+    "lighthouse-pwa-score": {
+      "type": "number",
+      "description": "Lighthouse Progressive Web App Score"
+    },
+  
+    "js-parse-compile": { "type": "number", "description": "JS Parse & Compile" },
+    "dom-size": { "type": "number", "description": "DOM Element Count" },
+    "visually_complete_85": {
+      "type": "number",
+      "description": "85% Visually Complete"
+    },
+  
+    "visually_complete": { "type": "number", "description": "Visually Complete" },
+  
+    "consistently-interactive": {
+      "type": "number",
+      "description": "Time to Interactive"
+    },
+  
+    "first-interactive": { "type": "number", "description": "First CPU Idle" },
+  
+    "time-to-first-byte": {
+      "type": "number",
+      "description": "Time to First Byte"
+    },
+  
+    "estimated-input-latency": {
+      "type": "number",
+      "description": "Estimated input latency"
+    },
+    "speed_index": { "type": "number", "description": "Speed Index" },
+    "first-meaningful-paint": {
+      "type": "number",
+      "description": "First Meaningful Paint"
+    },
+  
+    "first-contentful-paint": {
+      "type": "number",
+      "description": "First Contentful Paint"
+    },
+    "firstRender": { "type": "number", "description": "First Paint" },
+    "image_body_size_in_bytes": {
+      "type": "number",
+      "description": "Total Image size in bytes"
+    },
+  
+    "image_size_in_bytes": {
+      "type": "number",
+      "description": "Total Image transferred"
+    },
+  
+    "font_body_size_in_bytes": {
+      "type": "number",
+      "description": "Total Webfont size in bytes"
+    },
+  
+    "font_size_in_bytes": {
+      "type": "number",
+      "description": "Total Webfont transferred"
+    },
+  
+    "js_body_size_in_bytes": {
+      "type": "number",
+      "description": "Total JavaScript size in bytes"
+    },
+  
+    "js_size_in_bytes": {
+      "type": "number",
+      "description": "Total JavaScript Transferred"
+    },
+  
+    "css_body_size_in_bytes": {
+      "type": "number",
+      "description": "Total CSS size in bytes"
+    },
+  
+    "css_size_in_bytes": {
+      "type": "number",
+      "description": "Total CSS transferred"
+    },
+  
+    "html_body_size_in_bytes": {
+      "type": "number",
+      "description": "Total HTML size in bytes"
+    },
+  
+    "html_size_in_bytes": {
+      "type": "number",
+      "description": "Total HTML transferred"
+    },
+  
+    "page_wait_timing": { "type": "number", "description": "Response time" },
+  
+    "page_size_in_bytes": {
+      "type": "number",
+      "description": "Total Page transferred"
+    },
+  
+    "page_body_size_in_bytes": {
+      "type": "number",
+      "description": "Total Page size in bytes"
+    },
+  
+    "asset_count": { "type": "number", "description": "Number of requests" },
+  
+    "onload": { "type": "number", "description": "onLoad" },
+  
+    "oncontentload": { "type": "number", "description": "onContentLoad" }
   }
 }

--- a/test/specs/configs/perf.yaml
+++ b/test/specs/configs/perf.yaml
@@ -24,3 +24,36 @@ strains:
     perf:
       device: iPhoneX
       connection: LTE
+      asset_count: 1
+      consistently-interactive: 1
+      css_body_size_in_bytes: 1
+      css_size_in_bytes: 1
+      dom-size: 1
+      estimated-input-latency: 1
+      first-contentful-paint: 1
+      first-interactive: 1
+      first-meaningful-paint: 1
+      firstRender: 1
+      font_body_size_in_bytes: 1
+      font_size_in_bytes: 1
+      html_body_size_in_bytes: 1
+      html_size_in_bytes: 1
+      image_body_size_in_bytes: 1
+      image_size_in_bytes: 1
+      js_body_size_in_bytes: 1
+      js_size_in_bytes: 1
+      js-parse-compile: 1
+      lighthouse-accessibility-score: 1
+      lighthouse-best-practices-score: 1
+      lighthouse-performance-score: 1
+      lighthouse-pwa-score: 1
+      lighthouse-seo-score: 1
+      oncontentload: 1
+      onload: 1
+      page_body_size_in_bytes: 1
+      page_size_in_bytes: 1
+      page_wait_timing: 1
+      speed_index: 1
+      time-to-first-byte: 1
+      visually_complete_85: 1
+      visually_complete: 1

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -46,7 +46,7 @@ describe('Validator Tests', () => {
     });
   });
 
-  ['valid.yaml', 'full.yaml', 'proxy.yaml'].forEach((filename) => {
+  ['valid.yaml', 'full.yaml', 'proxy.yaml', 'perf.yaml'].forEach((filename) => {
     it(`${filename} is valid`, async () => {
       await assertValid(filename);
     });


### PR DESCRIPTION
The performance metrics that determine what the minimum performance goals for a strain are have been missing from the schema, making it impossible to actually compare performance against
self-determined thresholds. This change adds the missing schemas and updates the documentation
