### PR TITLE
Relax GitURL schema: allow no ref - default to master

### DIFF
--- a/src/schemas/giturl.schema.json
+++ b/src/schemas/giturl.schema.json
@@ -56,7 +56,6 @@
   },
   "required": [
     "owner",
-    "repo",
-    "ref"
+    "repo"
   ]
 }

--- a/src/schemas/staticgiturl.schema.json
+++ b/src/schemas/staticgiturl.schema.json
@@ -74,7 +74,6 @@
   },
   "required": [
     "owner",
-    "repo",
-    "ref"
+    "repo"
   ]
 }

--- a/test/specs/configs/no-ref.yaml
+++ b/test/specs/configs/no-ref.yaml
@@ -1,0 +1,27 @@
+# Copyright 2018 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+version: 1
+
+definitions:
+  constants:
+    defaultRepo:
+      &myrepo
+      owner: adobe
+      repo: project-helix.io
+  strains:
+    base:
+      &basestrain
+      code: *myrepo
+      content: *myrepo
+      static: *myrepo
+
+strains:
+  - name: default
+    <<: *basestrain

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -63,6 +63,7 @@ describe('Validator Tests', () => {
     'many-code-repos.yaml',
     'urls.yaml',
     'urls-map.yaml',
+    'no-ref.yaml',
   ].forEach((filename) => {
     it(`${filename} is valid`, async () => {
       await assertValid(filename);


### PR DESCRIPTION
Second run for: https://github.com/adobe/helix-shared/issues/71

This should unlock the backward compatibility.