### PR TITLE
fix(conditions): restrict conditions schema

### DIFF
--- a/docs/conditions.schema.json
+++ b/docs/conditions.schema.json
@@ -17,33 +17,21 @@
     "meta:status": "stabilizing",
     "description": "A condition expression",
     "additionalProperties": false,
+    "minProperties": 1,
+    "maxProperties": 1,
     "properties": {
         "and": {
-            "oneOf": [
-                {
-                    "type": "array",
-                    "items": {
-                        "$ref": "https://ns.adobe.com/helix/shared/conditions"
-                    }
-                },
-                {
-                    "$ref": "https://ns.adobe.com/helix/shared/conditions"
-                }
-            ],
+            "type": "array",
+            "items": {
+                "$ref": "https://ns.adobe.com/helix/shared/conditions"
+            },
             "description": "All conditions in this list must be met"
         },
         "or": {
-            "oneOf": [
-                {
-                    "type": "array",
-                    "items": {
-                        "$ref": "https://ns.adobe.com/helix/shared/conditions"
-                    }
-                },
-                {
-                    "$ref": "https://ns.adobe.com/helix/shared/conditions"
-                }
-            ],
+            "type": "array",
+            "items": {
+                "$ref": "https://ns.adobe.com/helix/shared/conditions"
+            },
             "description": "Any conditions in this list must be met"
         },
         "not": {

--- a/docs/conditions.schema.md
+++ b/docs/conditions.schema.md
@@ -20,9 +20,9 @@ A condition expression
 
 | Property | Type | Required | Nullable | Defined by |
 |----------|------|----------|----------|------------|
-| [and](#and) | complex | Optional  | No | Conditions (this schema) |
+| [and](#and) | Conditions | Optional  | No | Conditions (this schema) |
 | [not](#not) | Conditions | Optional  | No | Conditions (this schema) |
-| [or](#or) | complex | Optional  | No | Conditions (this schema) |
+| [or](#or) | Conditions | Optional  | No | Conditions (this schema) |
 | `^url[=~]?$` | `string` | Pattern | No | Conditions (this schema) |
 | `^url\.hostname[=~]?$` | `string` | Pattern | No | Conditions (this schema) |
 | `^url\.path[=~]?$` | `string` | Pattern | No | Conditions (this schema) |
@@ -53,31 +53,18 @@ All conditions in this list must be met
 `and`
 
 * is optional
-* type: complex
+* type: Conditions
 * defined in this schema
 
 ### and Type
 
 
-**One** of the following *conditions* need to be fulfilled.
-
-
-#### Condition 1
-
-
-Array type: 
+Array type: Conditions
 
 All items must be of the type:
-* []() – `https://ns.adobe.com/helix/shared/conditions`
+* [Conditions](conditions.schema.md) – `https://ns.adobe.com/helix/shared/conditions`
 
 
-
-
-
-#### Condition 2
-
-
-* []() – `https://ns.adobe.com/helix/shared/conditions`
 
 
 
@@ -109,31 +96,18 @@ Any conditions in this list must be met
 `or`
 
 * is optional
-* type: complex
+* type: Conditions
 * defined in this schema
 
 ### or Type
 
 
-**One** of the following *conditions* need to be fulfilled.
-
-
-#### Condition 1
-
-
-Array type: 
+Array type: Conditions
 
 All items must be of the type:
-* []() – `https://ns.adobe.com/helix/shared/conditions`
+* [Conditions](conditions.schema.md) – `https://ns.adobe.com/helix/shared/conditions`
 
 
-
-
-
-#### Condition 2
-
-
-* []() – `https://ns.adobe.com/helix/shared/conditions`
 
 
 

--- a/src/schemas/conditions.schema.json
+++ b/src/schemas/conditions.schema.json
@@ -17,25 +17,17 @@
   "meta:status": "stabilizing",
   "description": "A condition expression",
   "additionalProperties": false,
+  "minProperties": 1,
+  "maxProperties": 1,
   "properties": {
     "and": {
-      "oneOf": [
-        {
-          "type": "array",
-          "items": { "$ref": "https://ns.adobe.com/helix/shared/conditions" }
-        },
-        { "$ref": "https://ns.adobe.com/helix/shared/conditions" }
-      ],
+      "type": "array",
+      "items": { "$ref": "https://ns.adobe.com/helix/shared/conditions" },
       "description": "All conditions in this list must be met"
     },
     "or": {
-      "oneOf": [
-        {
-          "type": "array",
-          "items": { "$ref": "https://ns.adobe.com/helix/shared/conditions" }
-        },
-        { "$ref": "https://ns.adobe.com/helix/shared/conditions" }
-      ],
+      "type": "array",
+      "items": { "$ref": "https://ns.adobe.com/helix/shared/conditions" },
       "description": "Any conditions in this list must be met"
     },
     "not": {

--- a/test/specs/configs/valid-conditions.yaml
+++ b/test/specs/configs/valid-conditions.yaml
@@ -41,31 +41,31 @@ strains:
     <<: *basestrain
     condition:
       and:
-        url.hostname: www.example.com
-        url.path: /
-        client_lat>: 45
+        - url.hostname: www.example.com
+        - url.path: /
+        - client_lat>: 45
 
   - 
     name: conditions
     <<: *basestrain
     condition:
       and:
-        url.hostname: www.example.com
-        url.path: /
-        client_lat>: 45
-        client_lon<: 0
-        client_gmt_offset<: 0
-        or:
-          referer~: ".*google.*"
-          client_name: Adobe
-          client_city=: San Jose
-          client_country_code: CH
-          not:
-            user_agent~: Mozilla
-          accept_language: fr
-          and:
-            time_day<: 1 # before monday
-            time_day>: 5 # after friday
-          url_param.foo=: bar # the one true answer
-          url_param.bar>: 42
+        - url.hostname: www.example.com
+        - url.path: /
+        - client_lat>: 45
+        - client_lon<: 0
+        - client_gmt_offset<: 0
+        - or:
+          - referer~: ".*google.*"
+          - client_name: Adobe
+          - client_city=: San Jose
+          - client_country_code: CH
+          - not:
+              user_agent~: Mozilla
+          - accept_language: fr
+          - and:
+            - time_day<: 1 # before monday
+            - time_day>: 5 # after friday
+          - url_param.foo=: bar # the one true answer
+          - url_param.bar>: 42
 


### PR DESCRIPTION
`and` and `or` must be arrays. `conditions` and `not` must have exactly one property

Fixes #95 and fixes #96