### PR TITLE
Fix SchemaDerivedConfig

### DIFF
--- a/src/SchemaDerivedConfig.js
+++ b/src/SchemaDerivedConfig.js
@@ -77,22 +77,27 @@ class SchemaDerivedConfig extends BaseConfig {
   defaultHandler(root) {
     return {
       get: (target, prop) => {
-        if (prop === 'then') {
-          return target[prop];
+        if (this[prop]) {
+          return this[prop];
         }
-        if (prop === 'toJSON') {
-          return () => this._cfg;
-        }
-        const handler = this.getHandler(`${root}/${prop}`);
-        const handled = handler && target[prop] ? new Proxy(target[prop], handler) : target[prop];
+        if (typeof prop === 'string') {
+          const handler = this.getHandler(`${root}/${prop}`);
+          const handled = handler && target[prop] ? new Proxy(target[prop], handler) : target[prop];
 
-        if (typeof handled === 'object') {
-          // we are getting an object, so better wrap it again to
-          // intercept property access
-          return new Proxy(handled, this.defaultHandler(`${root}/${prop}`));
+          if (typeof handled === 'object') {
+            // we are getting an object, so better wrap it again to
+            // intercept property access
+            const wrapped = new Proxy(handled, this.defaultHandler(`${root}/${prop}`));
+
+            if (wrapped.length) {
+              return Array.from(wrapped);
+            }
+            return wrapped;
+          }
+          // this is a plain value
+          return handled;
         }
-        // this is a plain value
-        return handled;
+        return undefined;
       },
     };
   }
@@ -125,7 +130,18 @@ class SchemaDerivedConfig extends BaseConfig {
 
     this._content = new Proxy(this._cfg, this.defaultHandler(''));
 
-    return this._content;
+    // redefine getters
+    Object.keys(this._cfg).forEach((key) => {
+      if (typeof this[key] === 'undefined') {
+        this[key] = this._content[key];
+      }
+    });
+
+    return this;
+  }
+
+  toJSON() {
+    return this._cfg;
   }
 }
 

--- a/test/indexconfigs.test.js
+++ b/test/indexconfigs.test.js
@@ -56,6 +56,24 @@ describe('Index Config Loading', () => {
     });
   });
 
+  it('Does not trip over unset config', async () => {
+    const cfg = await new IndexConfig().init();
+    const actual = cfg.toJSON();
+    const expected = JSON.parse(await fs.readFile(path.resolve(SPEC_ROOT, 'empty-query.json'), 'utf-8'));
+
+    assert.deepEqual(actual, expected);
+  });
+
+  it('Does not trip over non-existing config', async () => {
+    const cfg = await new IndexConfig()
+      .withDirectory(SPEC_ROOT)
+      .init();
+    const actual = cfg.toJSON();
+    const expected = JSON.parse(await fs.readFile(path.resolve(SPEC_ROOT, 'empty-query.json'), 'utf-8'));
+
+    assert.deepEqual(actual, expected);
+  });
+
   it('theblog Index Config get loaded', async () => {
     const cfg = await new IndexConfig()
       .withConfigPath(path.resolve(SPEC_ROOT, 'query.yaml'))

--- a/test/specs/queryconfigs/query.json
+++ b/test/specs/queryconfigs/query.json
@@ -1,6 +1,7 @@
 {
   "indices": {
     "blog-posts": {
+      "name": "blog-posts",
       "fetch": "https://${repo}-${owner}.project-helix.page/${path}",
       "properties": {
         "author": {


### PR DESCRIPTION
Fixes some smaller issues:

1. expected that the result of `init()` was used, which is incompatible with the usage in `helix-cli`
2. some array-like properties weren't proper arrays, leading to "adventurous" code like this: https://github.com/adobe/helix-publish/pull/288#pullrequestreview-346279568