### PR TITLE
chore(deps): automerge minor & patch orb updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,11 @@
       "patch": {
         "automerge": true
       }
+    },
+    {
+      "datasources": ["orb"],
+      "updateTypes": ["patch", "minor"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Enable automerging for CircleCI orb updates of type minor and patch.
