### PR TITLE
fix(condition): prefix match fails if already contains trailing slash

### DIFF
--- a/src/Condition.js
+++ b/src/Condition.js
@@ -289,7 +289,8 @@ class URLCondition extends PropertyCondition {
   }
 
   prefixMatch(actual, prefix) {
-    if (actual === prefix || actual.startsWith(`${prefix}/`)) {
+    const dir = prefix.replace(/\/+$/, '');
+    if (actual === prefix || actual.startsWith(`${dir}/`)) {
       const { path } = this._uri;
       return path !== '/' ? { baseURL: path } : true;
     }

--- a/test/specs/conditions/url_slash.yaml
+++ b/test/specs/conditions/url_slash.yaml
@@ -1,0 +1,8 @@
+# Assert that condition URLs with ending slashes still match as a prefix
+
+condition:
+  url: https://www.example.com/
+
+samples:
+  - uri: https://www.example.com/docs/api/index.json
+    match: true


### PR DESCRIPTION
fix #274 