### PR TITLE
Fix for missing fiterability in empty mount configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-shared",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/IndexConfig.js
+++ b/src/IndexConfig.js
@@ -58,9 +58,6 @@ class IndexConfig extends SchemaDerivedConfig {
    * @param {string} queryname name of the query
    */
   getQuery(indexname, queryname) {
-    if (!Array.isArray(this.indices)) {
-      return undefined;
-    }
     const [myindex] = this.indices.filter((index) => index.name === indexname);
     if (!myindex) {
       return undefined;

--- a/src/SchemaDerivedConfig.js
+++ b/src/SchemaDerivedConfig.js
@@ -93,7 +93,7 @@ class SchemaDerivedConfig extends BaseConfig {
             // intercept property access
             const wrapped = new Proxy(handled, this.defaultHandler(`${root}/${prop}`));
 
-            if (wrapped.length) {
+            if (typeof wrapped.length === 'number') {
               return Array.from(wrapped);
             }
             return wrapped;

--- a/test/mountpoints.test.js
+++ b/test/mountpoints.test.js
@@ -76,6 +76,13 @@ describe('Mount Point Config Loading', () => {
     assert.equal(cfg.mountpoints[0].url, 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog?csf=1&e=8Znxth');
   });
 
+  it('Empty Mount Points gets properly evaluated', async () => {
+    const cfg = await new MountConfig()
+      .withConfigPath(path.resolve(SPEC_ROOT, 'empty.yaml'))
+      .init();
+    assert.equal(cfg.match('/nomach'), null);
+  });
+
   it('complex Mount Points gets properly evaluated', async () => {
     const cfg = await new MountConfig()
       .withConfigPath(path.resolve(SPEC_ROOT, 'complex.yaml'))


### PR DESCRIPTION
This fixes an issue introduced in #296 that prevented running the `.match()` function on empty mount configs