### PR TITLE
feat(config): add 'withRepoURL(GitUrl)' to base config

### DIFF
--- a/src/BaseConfig.js
+++ b/src/BaseConfig.js
@@ -12,6 +12,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const YAML = require('yaml');
+const GitUrl = require('./GitUrl.js');
 const cache = require('./fetchconfig/cache');
 const fetch = require('./fetchconfig/fetch');
 
@@ -44,7 +45,7 @@ class BaseConfig {
   /**
    * Reset the cache with a new cache size
    * @param {object} options cache options
-   * @param {integer} options.maxSize
+   * @param {number} options.maxSize
    */
   withCache(options) {
     cache.options(options);
@@ -61,8 +62,24 @@ class BaseConfig {
    * @param {string} options.headers.authorization authorization token to include
    */
   withRepo(owner, repo, ref, options = {}) {
+    return this.withRepoURL(new GitUrl({
+      owner,
+      repo,
+      ref,
+    }), options);
+  }
+
+  /**
+   * Set the base repository to fetch the config from.
+   * @param {GitUrl} url The git url of the repository
+   * @param {object} options options
+   * @param {object} options.headers headers to be used for HTTP request
+   * @param {string} options.headers.authorization authorization token to include
+   */
+  withRepoURL(url, options) {
     this._repo = {
-      owner, repo, ref, options,
+      url,
+      options,
     };
     return this;
   }
@@ -128,7 +145,6 @@ class BaseConfig {
         // fetch the config file from the repo
         this._source = await fetch({
           ...this._repo,
-          root: 'https://raw.githubusercontent.com',
           name: this._name,
           log: this._logger,
         });

--- a/src/fetchconfig/cache.js
+++ b/src/fetchconfig/cache.js
@@ -71,7 +71,7 @@ function cache(fn, opts = {}) {
  * Resets the QuickLRU cache with new options. Existing cache entries
  * will be cleared.
  * @param {object} opts options
- * @param {integer} opts.maxSize maximum size of the cache
+ * @param {number} opts.maxSize maximum size of the cache
  */
 cache.options = (opts) => {
   lru = new QuickLRU(opts);

--- a/src/fetchconfig/fetch.js
+++ b/src/fetchconfig/fetch.js
@@ -9,54 +9,36 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-const URL = require('url');
 const { fetch } = require('@adobe/helix-fetch').context({
   httpsProtocols:
   /* istanbul ignore next */
-  process.env.HELIX_FETCH_FORCE_HTTP1 ? ['http1'] : ['http2', 'http1'],
+    process.env.HELIX_FETCH_FORCE_HTTP1 ? ['http1'] : ['http2', 'http1'],
 });
 const utils = require('../utils');
 const cache = require('./cache');
 
-function computeGithubURI(root, owner, repo, ref, path) {
-  const rootURI = URL.parse(root);
-  const rootPath = rootURI.path;
-  // remove double slashes
-  const fullPath = `${rootPath}/${owner}/${repo}/${ref}/${path}`.replace(
-    /\/+/g,
-    '/',
-  );
-
-  rootURI.pathname = fullPath;
-
-  return URL.format(rootURI);
-}
-
 /**
  * Fetches an FSTab file from a GitHub repository
  * @param {object} opts options
- * @param {string} opts.root base URL for GitHub
- * @param {string} opts.owner GitHub owner or org
- * @param {string} opts.repo GitHub repository
- * @param {string} opts.ref GitHub ref
+ * @param {GitUrl} opts.url the git url of the repo
  * @param {string} opts.name Name of the Config File to fetch
  * @param {object} opts.log Helix-Log instance
  * @param {object} opts.options HTTP request options
  */
 async function fetchConfigUncached(opts) {
   const {
-    root, owner, repo, ref, log, options, name,
+    url, log, options, name,
   } = opts;
-  const response = await fetch(computeGithubURI(root, owner, repo, ref, name), options);
+  const response = await fetch(`${url.raw}/${name}`, options);
   const text = await response.text();
   if (response.ok) {
     return text;
   } else if (response.status === 404) {
-    log.info(`No fstab.yaml found in repo ${owner}/${repo}, ${text}`);
+    log.info(`No ${name} found in repo ${url.owner}/${url.repo}, ${text}`);
     return '';
   }
-  log[utils.logLevelForStatusCode(response.status)](`Invalid response (${response.status}) when fetching ${name} for ${owner}/${repo}`);
-  const err = new Error('Unable to fetch fstab', text);
+  log[utils.logLevelForStatusCode(response.status)](`Invalid response (${response.status}) when fetching ${name} for ${url.owner}/${url.repo}`);
+  const err = new Error(`Unable to fetch ${name}: ${text}`);
   err.status = utils.propagateStatusCode(response.status);
   throw err;
 }

--- a/test/mountpoints.test.js
+++ b/test/mountpoints.test.js
@@ -86,7 +86,7 @@ describe('Mount Point Config Loading (from GitHub)', () => {
         .init();
       assert.fail('This should have thrown');
     } catch (e) {
-      assert.equal(e.message, 'Unable to fetch fstab');
+      assert.equal(e.message, 'Unable to fetch fstab.yaml: Service Unavailable');
     }
   });
 });


### PR DESCRIPTION
Adds a new method `BaseConfig.withRepoURL()` that allows to set the git coordinates using a git url. this has the advantage, that it also contains the repository root.