### PR TITLE
chore(renovate): simplified config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,46 +6,32 @@
   "timezone": "Europe/Zurich",
   "packageRules": [
     {
-      "updateTypes": ["patch", "pin", "digest"],
-      "automerge": true,
-      "schedule": [
-        "at any time"
-      ],
-      "groupName": "fixes"
-    },{
-      "updateTypes": ["minor"],
-      "automerge": true,
-      "schedule": [
-        "at any time"
-      ],
-      "groupName": "minor"
-    },
-    {
       "packagePatterns": [
         "^@adobe/"
+      ],
+      "schedule": [
+        "at any time"
       ],
       "groupName": "@adobe",
       "automerge": true,
       "major": {
         "automerge": false
       },
-      "schedule": [
-        "at any time"
-      ]
     },
     {
-      "schedule": [
-        "after 2pm on Monday"
-      ],
       "packagePatterns": [
         "^.+"
       ],
       "excludePackagePatterns": [
         "^@adobe/"
       ],
+      "schedule": [
+        "after 2pm on Monday"
+      ],
       "groupName": "external",
-      "patch": {
-        "automerge": true
+      "automerge": true,
+      "major": {
+        "automerge": false
       }
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -6,33 +6,34 @@
   "timezone": "Europe/Zurich",
   "packageRules": [
     {
-      "packagePatterns": [
-        "^@adobe/"
-      ],
-      "schedule": [
-        "at any time"
-      ],
-      "groupName": "@adobe",
+      "groupName": "@adobe fixes",
+      "updateTypes": ["patch", "pin", "digest", "minor"],
       "automerge": true,
-      "major": {
-        "automerge": false
-      },
+      "packagePatterns": ["^@adobe/"],
+      "schedule": ["at any time"],
     },
     {
-      "packagePatterns": [
-        "^.+"
-      ],
-      "excludePackagePatterns": [
-        "^@adobe/"
-      ],
-      "schedule": [
-        "after 2pm on Monday"
-      ],
-      "groupName": "external",
+      "groupName": "@adobe major",
+      "updateTypes": ["major"],
+      "packagePatterns": ["^@adobe/"],
+      "automerge": false,
+      "schedule": ["at any time"]
+    },
+    {
+      "groupName": "external fixes",
+      "updateTypes": ["patch", "pin", "digest", "minor"],
       "automerge": true,
-      "major": {
-        "automerge": false
-      }
+      "schedule": ["after 2pm on Saturday"],
+      "packagePatterns": ["^.+"],
+      "excludePackagePatterns": ["^@adobe/"]
+    },
+    {
+      "groupName": "external major",
+      "updateTypes": ["major"],
+      "automerge": false,
+      "packagePatterns": ["^.+"],
+      "excludePackagePatterns": ["^@adobe/"],
+      "schedule": ["after 2pm on Monday"]
     },
     {
       "datasources": ["orb"],
@@ -44,3 +45,4 @@
     "npmToken": "mk0AasloZFiNy0v8xIYJ4b5pMkY2dpGMCWBXY+vFtlG+X74ENpf2MxYGmJR4Ljel12RkflYffjPuCvCQLTkKVaOwLqnXBROZj+ZXL66dBw/Lj8HnPt8NeBJ2iY6tzBtMxKKp3qpa6nAYuVQ1aBdusKAe5cgm2RU9/4JG/p1l5r05CI11+oGVQptNnuHCD67bcGPLWqLwedbNFztOdUhr1W9pNP6aSq1FpAOFWsx4P4NRNbX1CmqbOe57gyDi3C8bpjTjMRqBfbWPTReZqZXiTsjLskEY2RUah0GbP2RZ3jWZV3KurW/yxFIXaJXNGmH0KJzKKBGxTZ90Qm5r8/l1Jw=="
   }
 }
+


### PR DESCRIPTION
simplified the renovate config:
- all external packages are updated every week, automege only disabled to major updates.
- all internal packages are updated any time, automege only disabled to major updates.
