### PR TITLE
feat(mount): support mounting of documents

### DIFF
--- a/src/MountPointHandler.js
+++ b/src/MountPointHandler.js
@@ -19,11 +19,18 @@ const MountPointHandler = (decorators) => ({
 
       const obj = typeof config === 'string' ? {
         url: config,
-        path: path.endsWith('/') ? path : `${path}/`,
       } : {
         ...config,
-        path: path.endsWith('/') ? path : `${path}/`,
       };
+      // append trailing slash for paths w/o extension
+      const idxLastSlash = path.lastIndexOf('/');
+      const idx = path.lastIndexOf('.');
+      if (idxLastSlash !== path.length - 1 && idx < idxLastSlash) {
+        obj.path = `${path}/`;
+      } else {
+        obj.path = path;
+        obj.isDocument = idxLastSlash !== path.length - 1;
+      }
 
       const decorator = decorators.find((d) => d.test(obj));
 

--- a/test/mountpoints.test.js
+++ b/test/mountpoints.test.js
@@ -148,6 +148,11 @@ describe('Mount Point Config Loading', () => {
     assert.equal(cfg.mountpoints.length, 1);
     assert.equal(cfg.mountpoints[0].path, '/');
     assert.equal(cfg.mountpoints[0].url, 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog?csf=1&e=8Znxth');
+
+    const m1 = cfg.match('/index.md');
+    assert.equal(m1.type, 'onedrive');
+    assert.equal(m1.url, 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog?csf=1&e=8Znxth');
+    assert.equal(m1.relPath, '/index.md');
   });
 
   it('Empty Mount Points gets properly evaluated', async () => {
@@ -163,10 +168,11 @@ describe('Mount Point Config Loading', () => {
       .init();
     assert.equal(cfg.match('/nomach'), null);
 
-    const m1 = cfg.match('/ms/en/posts/testdocument');
+    const m1 = cfg.match('/ms/en/posts/testdocument.md');
     assert.equal(m1.type, 'onedrive');
+    assert.equal(m1.isDocument, undefined);
     assert.equal(m1.url, 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog');
-    assert.equal(m1.relPath, '/en/posts/testdocument');
+    assert.equal(m1.relPath, '/en/posts/testdocument.md');
 
     const m2 = cfg.match('/ms/docs/different');
     assert.equal(m2.type, 'onedrive');
@@ -177,6 +183,7 @@ describe('Mount Point Config Loading', () => {
     const m3 = cfg.match('/gd/document42');
     assert.equal(m3.type, 'google');
     assert.equal(m3.url, 'https://drive.google.com/drive/u/0/folders/123456789');
+    assert.equal(m3.path, '/gd/');
     assert.equal(m3.id, '123456789');
     assert.equal(m3.fallbackPath, 'default.md');
     assert.equal(m3.relPath, '/document42');
@@ -196,6 +203,28 @@ describe('Mount Point Config Loading', () => {
     assert.equal(m6.type, 'onedrive');
     assert.equal(m6.url, 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog', 'is confused by slashes');
     assert.equal(m6.relPath, '');
+
+    // onedrive document check with extension
+    const m7 = cfg.match('/onedrive-index');
+    assert.equal(m7.type, 'onedrive');
+    assert.equal(m7.path, '/onedrive-index.md');
+    assert.equal(m7.url, 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog/homepage.docx');
+    assert.equal(m7.isDocument, true);
+    assert.equal(m7.relPath, '');
+
+    // google drive document check
+    const m8 = cfg.match('/google-index');
+    assert.equal(m8.type, 'google');
+    assert.equal(m8.url, 'gdrive:complexitemid');
+    assert.equal(m8.id, 'complexitemid');
+    assert.equal(m8.isDocument, true);
+    assert.equal(m8.relPath, '');
+
+    // onedrive with onedrive uri
+    const m9 = cfg.match('/mswithid/foo');
+    assert.equal(m9.type, 'onedrive');
+    assert.equal(m9.url, 'onedrive:/drives/1234/items/5678');
+    assert.equal(m9.relPath, '/foo');
 
     assert.equal(cfg.match('/mssoft'), null, 'requires trailing slash in matches');
   });

--- a/test/specs/mountconfigs/complex.json
+++ b/test/specs/mountconfigs/complex.json
@@ -6,6 +6,9 @@
       "url": "https://drive.google.com/drive/u/0/folders/123456789",
       "fallbackPath": "default.md"
     },
-    "/foo": "https://localhost:4502"
+    "/mswithid": "onedrive:/drives/1234/items/5678",
+    "/foo/": "https://localhost:4502",
+    "/google-index.md": "gdrive:complexitemid",
+    "/onedrive-index.md": "https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog/homepage.docx"
   }
 }

--- a/test/specs/mountconfigs/complex.yaml
+++ b/test/specs/mountconfigs/complex.yaml
@@ -1,7 +1,10 @@
 mountpoints:
   /ms/docs: https://adobe.sharepoint.com/sites/docs?fallbackPath=default.docx
   /ms:      https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog
-  /gd:      
+  /gd:
     url: https://drive.google.com/drive/u/0/folders/123456789
     fallbackPath: default.md
-  /foo:     https://localhost:4502
+  /mswithid: onedrive:/drives/1234/items/5678
+  /foo/:     https://localhost:4502
+  /google-index.md: gdrive:complexitemid
+  /onedrive-index.md: https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog/homepage.docx


### PR DESCRIPTION
fixes #342

- also adds support for `onedrive:` uris see https://github.com/adobe/helix-onedrive-support/issues/68
- this will fix https://github.com/adobe/helix-word2md/issues/70 once added to content proxy