### PR TITLE
chore(renovate): limit webpack version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
   "timezone": "Europe/Zurich",
   "packageRules": [
     {
+      "packageNames": ["webpack"],
+      "allowedVersions": "<5.0.0"
+    },
+    {
       "groupName": "@adobe fixes",
       "updateTypes": ["patch", "pin", "digest", "minor"],
       "automerge": true,


### PR DESCRIPTION
limits the webpack version to `4.x`.