### PR TITLE
feat(log): info on 4xx

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,7 @@ function lookupBackendResponses(status) {
     return { status: 503, level: 'error' };
     // report as: Service Unavailable
   } else if (status < 500) {
-    return { status, level: 'warn' };
+    return { status, level: 'info' };
   } else if (status === 500) {
     // Internal Server error in the backend
     return { status: 502, level: 'error' };

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,12 +22,14 @@ const crypto = require('crypto');
 function lookupBackendResponses(status) {
   if (status < 400) {
     return { status, level: 'verbose' };
+  } else if (status === 404) {
+    return { status, level: 'info' };
   } else if (status === 429) {
     // Too Many Requests in the backend
     return { status: 503, level: 'error' };
     // report as: Service Unavailable
   } else if (status < 500) {
-    return { status, level: 'info' };
+    return { status, level: 'warn' };
   } else if (status === 500) {
     // Internal Server error in the backend
     return { status: 502, level: 'error' };

--- a/test/backendmapping.test.js
+++ b/test/backendmapping.test.js
@@ -46,7 +46,7 @@ describe('Test Log Level Determination', () => {
     assert.equal(logLevelForStatusCode(401), 'warn');
     assert.equal(logLevelForStatusCode(402), 'warn');
     assert.equal(logLevelForStatusCode(403), 'warn');
-    assert.equal(logLevelForStatusCode(404), 'warn');
+    assert.equal(logLevelForStatusCode(404), 'info');
     assert.equal(logLevelForStatusCode(405), 'warn');
     assert.equal(logLevelForStatusCode(406), 'warn');
     assert.equal(logLevelForStatusCode(407), 'warn');


### PR DESCRIPTION
Fix adobe/helix-content-proxy#239

Impact is limited since the method `logLevelForStatusCode ` is used only in the content-proxy and data-embed where in both cases we only want an info log entry for 4xx.
