### PR TITLE
build(renovate.json): prevent updates to helix-fetch@2.0.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
       "allowedVersions": "<5.0.0"
     },
     {
+      "packageNames": ["@adobe/helix-fetch"],
+      "allowedVersions": "<2.0.0"
+    },
+    {
       "groupName": "adobe fixes",
       "updateTypes": ["patch", "pin", "digest", "minor"],
       "automerge": true,


### PR DESCRIPTION
[helix-fetch@2.0.0](https://github.com/adobe/helix-fetch/pull/116) includes breaking changes; dependants should be manually migrated one-by-one

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://github.com/adobe/helix-fetch/pull/116

Thanks for contributing!
