### PR TITLE
refactor(schema): clarify the format of the package parameter

### DIFF
--- a/src/schemas/runtimestrain.schema.json
+++ b/src/schemas/runtimestrain.schema.json
@@ -82,7 +82,7 @@
           ]
         },
         {
-          "description": "The Universal Runtime base URL to use for all actions in this strain.",
+          "description": "A base URL to use for all actions in this strain.",
           "type": "string",
           "format": "uri",
           "examples": [

--- a/src/schemas/runtimestrain.schema.json
+++ b/src/schemas/runtimestrain.schema.json
@@ -63,8 +63,33 @@
       "type": "boolean"
     },
     "package": {
-      "description": "Name of the action package that renders this strain.",
-      "type": "string"
+      "oneOf": [
+        {
+          "description": "Name of the action package that renders this strain.",
+          "type": "string",
+          "pattern": "^[^/]*$",
+          "examples": [
+            "10e05c072b108ac9533c6206c6eaa651901ca29b"
+          ]
+        },
+        {
+          "description": "A pair of OpenWhisk namespace and package name, separated by slash.\n\n This will be the base package to look up actions to run in this strain.",
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$",
+          "examples": [
+            "helix-pages/pages_4.15.1",
+            "trieloff/10e05c072b108ac9533c6206c6eaa651901ca29b"
+          ]
+        },
+        {
+          "description": "The Universal Runtime base URL to use for all actions in this strain.",
+          "type": "string",
+          "format": "uri",
+          "examples": [
+            "https://helix-pages.anywhere.run/helix-pages/pages@4.15.1"
+          ]
+        }
+      ]
     },
     "url": {
       "description": "URL condition.\n\n**Warning**: this property has been deprecated in favour of adding the `url` to the `condition` property.",


### PR DESCRIPTION
prior to the change, the package parameter was simply a string, now it is either 
- (1) a string without slashes – old format, 
- (2) a string with exactly one slash – current format, 
- (3) a URI – new format

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
