### PR TITLE
fix: re-enable HTTP/2

### DIFF
--- a/src/DynamicRedirect.js
+++ b/src/DynamicRedirect.js
@@ -12,9 +12,6 @@
 const { URL } = require('url');
 const fetchAPI = require('@adobe/helix-fetch');
 
-// force HTTP/1 in order to avoid issues with long-lived HTTP/2 sessions
-// on azure/kubernetes based I/O Runtime
-process.env.HELIX_FETCH_FORCE_HTTP1 = true;
 const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1
   ? fetchAPI.context({
     alpnProtocols: [fetchAPI.ALPN_HTTP1_1],


### PR DESCRIPTION
As a precautionary measure HTTP/2 had been disabled in order to avoid issues related to the runtime migration to Azure. We've since re-implemented the http client (fetch) and now it's time to re-enable HTTP/2.

> Note that flag to disable HTTP/2 (an env variable) had leaked to all dependants of `helix-shared`, effectively disabling HTTP/2 there too. 
