### PR TITLE
fix: make some properties required

### DIFF
--- a/src/schemas/index.schema.json
+++ b/src/schemas/index.schema.json
@@ -47,5 +47,10 @@
         "$ref": "https://ns.adobe.com/helix/shared/query"
       }
     }
-  }
+  },
+  "required": [
+    "source",
+    "fetch",
+    "properties"
+  ]
 }


### PR DESCRIPTION
Noticed while adding a new index in a project and forgetting one of those. These should all be required.

Note, that `target` - when omitted - defaults to an Algolia index. Might be worth changing this behaviour, e.g. make `target` required as well.