### PR TITLE
use universal runtime for redirects

### DIFF
--- a/src/BaseConfig.js
+++ b/src/BaseConfig.js
@@ -59,6 +59,15 @@ class BaseConfig {
   }
 
   /**
+   * Empty method to allow subclasses to intercept setting the
+   * GitHub token, if authentication option are provided in the
+   * repo options.
+   */
+  withGithubToken() {
+    return this;
+  }
+
+  /**
    * Set the base repository to fetch a config from
    * @param {string} owner username or org
    * @param {string} repo repository
@@ -87,6 +96,9 @@ class BaseConfig {
       url,
       options,
     };
+    if (options && options.headers && /^token /.test(options.headers.authorization)) {
+      this.withGithubToken(options.headers.authorization.replace(/token /, ''));
+    }
     return this;
   }
 

--- a/src/DynamicRedirect.js
+++ b/src/DynamicRedirect.js
@@ -75,10 +75,8 @@ class DynamicRedirect {
       try {
         let url = new URL(this._src);
         if (!this._src.endsWith('.json')) {
-        // load via runtime (todo: do this via a plugin)
-        // eslint-disable-next-line no-underscore-dangle
-          const namespace = process.env.__OW_NAMESPACE || 'helix';
-          url = new URL(`https://adobeioruntime.net/api/v1/web/${namespace}/helix-services/data-embed@v1`);
+        // load via universal runtime (todo: do this via a plugin)
+          url = new URL('https://helix-pages.anywhere.run/helix-services/data-embed@v2');
           url.searchParams.append('src', this._src);
         }
         const res = await fetch(url.href, {

--- a/src/DynamicRedirect.js
+++ b/src/DynamicRedirect.js
@@ -57,10 +57,16 @@ class DynamicRedirect {
     this._data = null;
     this._logger = logger;
     this._transactionID = null;
+    this._githubToken = null;
   }
 
   withTransactionID(id) {
     this._transactionID = id;
+    return this;
+  }
+
+  withGithubToken(token) {
+    this._githubToken = token;
     return this;
   }
 
@@ -78,6 +84,7 @@ class DynamicRedirect {
         const res = await fetch(url.href, {
           headers: {
             'x-request-id': this._transactionID,
+            'x-github-token': this._githubToken,
           },
         });
         const text = await res.text();

--- a/src/RedirectConfig.js
+++ b/src/RedirectConfig.js
@@ -45,6 +45,11 @@ class RedirectConfig extends SchemaDerivedConfig {
     return this;
   }
 
+  withGithubToken(token) {
+    this.rrhandler.withGithubToken(token);
+    return this;
+  }
+
   async match(path) {
     const resolved = await Promise.all(this.redirects.map((redirect) => redirect.match(path)));
     return resolved.find((o) => o);

--- a/src/RedirectRuleHandler.js
+++ b/src/RedirectRuleHandler.js
@@ -23,6 +23,11 @@ const RedirectRuleHandler = () => ({
     return this;
   },
 
+  withGithubToken(token) {
+    this._token = token;
+    return this;
+  },
+
   get(target, prop) {
     const index = Number.parseInt(prop, 10);
     if (!Number.isNaN(index) && index >= 0) {
@@ -32,6 +37,7 @@ const RedirectRuleHandler = () => ({
         return new Redirect(item);
       }
       return new DynamicRedirect(item, this.logger)
+        .withGithubToken(this._token)
         .withTransactionID(this._transactionID);
     }
     return target[prop];

--- a/test/mountpoints.test.js
+++ b/test/mountpoints.test.js
@@ -36,7 +36,7 @@ describe('Mount Point Config Loading (from GitHub)', () => {
     assert.equal(match.url, 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog');
   });
 
-  it.skip('Retrieves Document from GitHub with Auth', async function okGithub() {
+  it('Retrieves Document from GitHub with Auth', async function okGithub() {
     const { server } = this.polly;
     let foundtoken;
     let foundid;
@@ -53,7 +53,7 @@ describe('Mount Point Config Loading (from GitHub)', () => {
     const config = await new MountConfig()
       .withCache({ maxSize: 1 })
       .withRepo('adobe', 'theblog', '7f65c0399b1b925ececf55becd4b150c357-auth', {
-        headers: { Authorization: 'fake' },
+        headers: { authorization: 'fake' },
       })
       .withTransactionID('random')
       .init();

--- a/test/mountpoints.test.js
+++ b/test/mountpoints.test.js
@@ -53,7 +53,7 @@ describe('Mount Point Config Loading (from GitHub)', () => {
     const config = await new MountConfig()
       .withCache({ maxSize: 1 })
       .withRepo('adobe', 'theblog', '7f65c0399b1b925ececf55becd4b150c357-auth', {
-        headers: { authorization: 'fake' },
+        headers: { authorization: 'token fake' },
       })
       .withTransactionID('random')
       .init();
@@ -61,7 +61,7 @@ describe('Mount Point Config Loading (from GitHub)', () => {
     const match = config.match('/');
 
     assert.equal(foundid, 'random');
-    assert.equal(foundtoken, 'fake');
+    assert.equal(foundtoken, 'token fake');
     assert.equal(match.url, 'https://adobe.sharepoint.com/sites/TheBlog/Shared%20Documents/theblog');
   });
 

--- a/test/redirectconfigs.test.js
+++ b/test/redirectconfigs.test.js
@@ -29,7 +29,7 @@ describe('Redirects Config Loading (from GitHub)', () => {
   it('Retrieves Document from GitHub', async function get() {
     const { server } = this.polly;
 
-    server.get('https://adobeioruntime.net/api/v1/web/helix/helix-services/:path').intercept((req, res) => {
+    server.get('https://helix-pages.anywhere.run/helix-services/:path').intercept((req, res) => {
       assert.equal(req.headers['x-request-id'], 'random');
       assert.equal(req.headers['x-github-token'], 'fake');
 

--- a/test/redirectconfigs.test.js
+++ b/test/redirectconfigs.test.js
@@ -31,6 +31,7 @@ describe('Redirects Config Loading (from GitHub)', () => {
 
     server.get('https://adobeioruntime.net/api/v1/web/helix/helix-services/:path').intercept((req, res) => {
       assert.equal(req.headers['x-request-id'], 'random');
+      assert.equal(req.headers['x-github-token'], 'fake');
 
       if (req.query.src.startsWith('https://adobe.sharepoint.com/')) {
         return res.status(200).json([
@@ -100,6 +101,7 @@ describe('Redirects Config Loading (from GitHub)', () => {
       .withCache({ maxSize: 1 })
       .withConfigPath(path.resolve(SPEC_ROOT, 'dynamic.yaml'))
       .withTransactionID('random')
+      .withGithubToken('fake')
       .init();
 
     assert.deepEqual(config.toJSON().redirects, [


### PR DESCRIPTION
Fixes #480 by:

- using universal runtime instead of adobe i/o runtime
- passing the github token along

Drive-by-fixes:

- now uses data-embed@v2 (so we get the last six months of fixes and features)

Non-fixes (because they are non-issues)

- if the specified URL ends with `.json`, it is still being fetched directly, and with that using helix-content-proxy and the associated caches in most cases

Potential new issues

- the GitHub token is passed to all URLs ending with `.json`, and this includes potentially external servers that could grab the token from the request. We do not have a way of validating if a given external URL corresponds to a helix site on a private repo and thus needs the token or if sending the token is unneccessary or potentially harmful. 