### PR TITLE
feat(schema): add schemas for helix-data-embed

### DIFF
--- a/packages/helix-shared-config/src/schemas/data-embed-response.schema.json
+++ b/packages/helix-shared-config/src/schemas/data-embed-response.schema.json
@@ -1,0 +1,40 @@
+{
+  "meta:license": [
+    "Copyright 2021 Adobe. All rights reserved.",
+    "This file is licensed to you under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at http://www.apache.org/licenses/LICENSE-2.0",
+    "",
+    "Unless required by applicable law or agreed to in writing, software distributed under",
+    "the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS",
+    "OF ANY KIND, either express or implied. See the License for the specific language",
+    "governing permissions and limitations under the License."
+  ],
+  "$id": "https://ns.adobe.com/helix/data-embed/response",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Response",
+  "type": "object",
+  "meta:status": "stabilizing",
+  "description": "The Helix Data Embed Response format",
+  "allOf": [
+    {
+      "oneOf": [
+        { "$ref": "https://ns.adobe.com/helix/data-embed/workbook" },
+        { "$ref": "https://ns.adobe.com/helix/data-embed/sheet" }
+      ]
+    },
+    {
+      "version": {
+        "type": "number",
+        "enum": [3],
+        "default": 3,
+        "description": "The workbook response format version"
+      }
+    }
+  ],
+  "required": [
+    "version",
+    "type"
+  ],
+  "minProperties": 4
+}

--- a/packages/helix-shared-config/src/schemas/row.schema.json
+++ b/packages/helix-shared-config/src/schemas/row.schema.json
@@ -1,0 +1,23 @@
+{
+  "meta:license": [
+    "Copyright 2021 Adobe. All rights reserved.",
+    "This file is licensed to you under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at http://www.apache.org/licenses/LICENSE-2.0",
+    "",
+    "Unless required by applicable law or agreed to in writing, software distributed under",
+    "the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS",
+    "OF ANY KIND, either express or implied. See the License for the specific language",
+    "governing permissions and limitations under the License."
+  ],
+  "$id": "https://ns.adobe.com/helix/data-embed/row",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Row",
+  "type": "object",
+  "meta:status": "stabilizing",
+  "description": "A JSON representation of an Excel or Google Sheets data row.",
+  "additionalProperties": {
+    "type": ["string", "number"],
+    "description": "Value of the cell in the given column."
+  }
+}

--- a/packages/helix-shared-config/src/schemas/sheet.schema.json
+++ b/packages/helix-shared-config/src/schemas/sheet.schema.json
@@ -1,0 +1,51 @@
+{
+  "meta:license": [
+    "Copyright 2021 Adobe. All rights reserved.",
+    "This file is licensed to you under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at http://www.apache.org/licenses/LICENSE-2.0",
+    "",
+    "Unless required by applicable law or agreed to in writing, software distributed under",
+    "the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS",
+    "OF ANY KIND, either express or implied. See the License for the specific language",
+    "governing permissions and limitations under the License."
+  ],
+  "$id": "https://ns.adobe.com/helix/data-embed/sheet",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Worksheet",
+  "type": "object",
+  "meta:status": "stabilizing",
+  "description": "A JSON representation of an Excel or Google Sheets worksheet containing rows and columns.",
+  "properties": {
+    "type": {
+      "const": "sheet",
+      "description": "The response type, depending on the presence of the `sheet` request parameter."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The maximum number of items requested by the `limit` parameter."
+    },
+    "offset": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The starting row that items have been retrieved by as specified by the `offset` parameter."
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The total number of items in the data sheet. This value can be greater than the sum of `limit` and `offset`"
+    },
+    "data": {
+      "type": "array",
+      "description": "The data rows that are part of the result set",
+      "items": {
+        "$ref": "https://ns.adobe.com/helix/data-embed/row"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "limit", "offset", "data", "total"
+  ]
+}

--- a/packages/helix-shared-config/src/schemas/workbook.schema.json
+++ b/packages/helix-shared-config/src/schemas/workbook.schema.json
@@ -1,0 +1,39 @@
+{
+  "meta:license": [
+    "Copyright 2021 Adobe. All rights reserved.",
+    "This file is licensed to you under the Apache License, Version 2.0 (the \"License\");",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at http://www.apache.org/licenses/LICENSE-2.0",
+    "",
+    "Unless required by applicable law or agreed to in writing, software distributed under",
+    "the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS",
+    "OF ANY KIND, either express or implied. See the License for the specific language",
+    "governing permissions and limitations under the License."
+  ],
+  "$id": "https://ns.adobe.com/helix/data-embed/workbook",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Workbook",
+  "type": "object",
+  "meta:status": "stabilizing",
+  "description": "A JSON representation of an Excel or Google Sheets workbook containing multiple sheets.",
+  "properties": {
+    "type": {
+      "const": "multi-sheet",
+      "description": "The response type, depending on the presence of the `sheet` request parameter."
+    },
+    "names": {
+      "type": "array",
+      "description": "The list of sheet names that exist in the workbook response.",
+      "items": {
+        "type": "string",
+        "description": "The sheet name"
+      }
+    }
+  },
+  "additionalProperties": {
+    "$ref": "https://ns.adobe.com/helix/data-embed/sheet"
+  },
+  "required": [
+    "names"
+  ]
+}


### PR DESCRIPTION
schemas for response (either workbook or worksheet + metadata), workbook, worksheet, and row. Response must have `type` and `version` properties now.

see https://github.com/adobe/helix-data-embed/pull/356#issuecomment-836357581
