### PR TITLE
fix: use and export ValidationError

### DIFF
--- a/packages/helix-shared-config/src/SchemaDerivedConfig.js
+++ b/packages/helix-shared-config/src/SchemaDerivedConfig.js
@@ -12,6 +12,7 @@
 const Ajv = require('ajv').default;
 const ajvFormats = require('ajv-formats');
 const BaseConfig = require('./BaseConfig.js');
+const ValidationError = require('./ValidationError.js');
 
 /**
  * A Helix Config that is based on a (number of) JSON Schema(s).
@@ -66,7 +67,7 @@ class SchemaDerivedConfig extends BaseConfig {
     if (res) {
       return res;
     }
-    throw new Error(ajv.errorsText());
+    throw new ValidationError(ajv.errorsText(), ajv.errors);
   }
 
   /**

--- a/packages/helix-shared-config/src/ValidationError.js
+++ b/packages/helix-shared-config/src/ValidationError.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+class ValidationError extends Error {
+  constructor(msg, errors = []) {
+    function prettyname(path, schema) {
+      if (path) {
+        if (path.startsWith('.strains')) {
+          return `${schema.title || 'Invalid Strain'} ${path.replace(/\.strains(\.|\[')(.*)/, '$2').replace(/'.*/, '')}`;
+        }
+        return `${schema.title || schema.$id} ${path}`;
+      }
+      return `${schema.title || schema.$id}`;
+    }
+
+    const detail = errors.map(({
+      keyword, dataPath, message, data, params, parentSchema,
+    }) => {
+      if (keyword === 'additionalProperties') {
+        return `${prettyname(dataPath, parentSchema)} has unknown property '${params.additionalProperty}'`;
+      }
+      if (keyword === 'required' && dataPath === '') {
+        return 'A set of strains and a default strain are missing.';
+      }
+      if (keyword === 'required' && dataPath === '.strains') {
+        return 'A default strain is missing.';
+      }
+      if (keyword === 'required') {
+        return `${prettyname(dataPath, parentSchema)} ${message}`;
+      }
+      if (keyword === 'oneOf' && dataPath.startsWith('.strains')) {
+        return `${prettyname(dataPath, parentSchema)} must be either a Runtime Strain or a Proxy Strain`;
+      }
+      return `${prettyname(dataPath, parentSchema)} ${message}: ${keyword}(${JSON.stringify(data)}, ${JSON.stringify(params)})`;
+    }).join('\n');
+    super(`Invalid configuration:
+${detail}
+
+${msg}`);
+    this._errors = errors;
+  }
+}
+
+module.exports = ValidationError;

--- a/packages/helix-shared-config/src/index.js
+++ b/packages/helix-shared-config/src/index.js
@@ -18,6 +18,7 @@ const MarkupConfig = require('./MarkupConfig');
 const Condition = require('./Condition.js');
 const { optionalConfig, requiredConfig } = require('./config-wrapper');
 const DataEmbedValidator = require('./DataEmbedValidator.js');
+const ValidationError = require('./ValidationError.js');
 
 module.exports = {
   HelixConfig,
@@ -30,4 +31,5 @@ module.exports = {
   optionalConfig,
   requiredConfig,
   DataEmbedValidator,
+  ValidationError,
 };

--- a/packages/helix-shared-config/test/markupconfig.test.js
+++ b/packages/helix-shared-config/test/markupconfig.test.js
@@ -67,7 +67,7 @@ describe('Markup Config Loading', () => {
       if (e instanceof AssertionError) {
         throw e;
       }
-      assert.equal(e.message, 'data/markup/images-in-gallery must have required property \'match\', data/markup/last-section must NOT have additional properties');
+      assert.equal(e.message, 'Invalid configuration:\nMarkup Mapping must have required property \'match\'\nMarkup Mapping has unknown property \'invalid\'\n\ndata/markup/images-in-gallery must have required property \'match\', data/markup/last-section must NOT have additional properties');
     }
   });
 });

--- a/packages/helix-shared-config/test/mountpoints.test.js
+++ b/packages/helix-shared-config/test/mountpoints.test.js
@@ -102,7 +102,7 @@ const tests = [
     title: 'fails with a broken config',
     config: 'broken.yaml',
     result: null,
-    error: 'Error: data must NOT have additional properties',
+    error: 'Error: Invalid configuration:\nFSTab (Mount Points) has unknown property \'mounts\'\n\ndata must NOT have additional properties',
   },
   {
     title: 'loads a theblog example',


### PR DESCRIPTION
Export ValidationError and use it to provide detailed error message in case SchemaDerivedConfig validation fails.