### PR TITLE
fix: fetch and source should be optional

### DIFF
--- a/packages/helix-shared-config/src/schemas/index.schema.json
+++ b/packages/helix-shared-config/src/schemas/index.schema.json
@@ -49,8 +49,6 @@
     }
   },
   "required": [
-    "source",
-    "fetch",
     "properties"
   ]
 }


### PR DESCRIPTION
With Helix 3, it turns out that `fetch` and source are optional, as they can be derived:
- `fetch`: https://{ref}--{repo}--{owner}.hlx3.live/{path}
- `source`: would contain the extension, but in Helix 3, we don't need to add `.html` anymore