### PR TITLE
fix(bounce): guard against missing `context.invocation`

### DIFF
--- a/packages/helix-shared-bounce/README.md
+++ b/packages/helix-shared-bounce/README.md
@@ -21,3 +21,10 @@
  module.exports.main = wrap(main)
    .with(bounce, { responder: fast });
  ```
+
+## Disabling Bouncing for Tests
+
+If you are testing a function that is using `bounce` locally, you might want to disable the bouncing for the duration of the test, because you would otherwise have
+to mock a larger part of the runtime.
+
+To disable bouncing for tests, set the `HELIX_DEBOUNCE` environment variable to any value.

--- a/packages/helix-shared-bounce/src/bounce.js
+++ b/packages/helix-shared-bounce/src/bounce.js
@@ -14,7 +14,7 @@ const crypto = require('crypto');
 
 function bounce(func, { responder, timeout = 500 }) {
   return async (request, context) => {
-    const id = request.headers.get('x-hlx-bounce-id');
+    const id = request.headers.get('x-hlx-bounce-id') || process.env.HELIX_DEBOUNCE;
     if (id) {
       // use the provided bounce id
       context.invocation.bounceId = id;

--- a/packages/helix-shared-bounce/src/bounce.js
+++ b/packages/helix-shared-bounce/src/bounce.js
@@ -24,6 +24,7 @@ function bounce(func, { responder, timeout = 500 }) {
 
     // generate a new bounce id and add it to the context
     const bounceId = crypto.randomUUID();
+    context.invocation = context.invocation || {};
     context.invocation.bounceId = bounceId;
 
     // run the quick responder function

--- a/packages/helix-shared-bounce/test/bounce.test.js
+++ b/packages/helix-shared-bounce/test/bounce.test.js
@@ -117,8 +117,6 @@ describe('Bounce Wrapper Unit Tests', () => {
       },
     }), {
       log,
-      invocation: {
-      },
     });
     assert.equal(response.status, 200, 'universal function should be executed');
     assert.equal(slowBounceId, fastBounceId);


### PR DESCRIPTION
when calling the function directly, for instance in a test, the `context.invocation` property may be unset. This patch guards against this case by initializing it with an empty object.
