### PR TITLE
feat: use base64url encoding for surrogate computation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   node14:
     docker:
-    - image: circleci/node:14
+    - image: cimg/node:14.18
     environment:
       NPM_CONFIG_PREFIX: ~/.npm-global
 

--- a/packages/helix-shared-utils/package.json
+++ b/packages/helix-shared-utils/package.json
@@ -23,5 +23,8 @@
   },
   "devDependencies": {
     "@adobe/helix-shared-git": "^1.1.0"
+  },
+  "engines": {
+    "node": ">= 14.17"
   }
 }

--- a/packages/helix-shared-utils/src/utils.js
+++ b/packages/helix-shared-utils/src/utils.js
@@ -53,7 +53,7 @@ function lookupBackendResponses(status) {
 function computeSurrogateKey(url) {
   const hmac = crypto.createHmac('sha256', 'helix'); // lgtm [js/hardcoded-credentials]
   hmac.update(String(url));
-  return hmac.digest('base64').substring(0, 16);
+  return hmac.digest('base64url').substring(0, 16);
 }
 
 /**

--- a/packages/helix-shared-utils/test/surrogate.test.js
+++ b/packages/helix-shared-utils/test/surrogate.test.js
@@ -19,11 +19,11 @@ const { computeSurrogateKey } = require('../src/utils.js');
 
 describe('Surrogate Test', () => {
   it('computes a string', () => {
-    assert.equal(computeSurrogateKey('input'), 'LryzWp9TSqzkYkz6');
+    assert.strictEqual(computeSurrogateKey('input'), 'LryzWp9TSqzkYkz6');
   });
 
   it('computes a empty string', () => {
-    assert.equal(computeSurrogateKey(''), '+furr1hlvWuvr9Xu');
+    assert.strictEqual(computeSurrogateKey(''), '-furr1hlvWuvr9Xu');
   });
 
   it('computes a git url', () => {
@@ -36,6 +36,6 @@ describe('Surrogate Test', () => {
       ref: 'products/v2',
       repo: 'repository',
     });
-    assert.equal(computeSurrogateKey(url), 'KRBwmXdLOShWtk9P');
+    assert.strictEqual(computeSurrogateKey(url), 'KRBwmXdLOShWtk9P');
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: the encoding for surrogate computation changed from the regular to the url-safe base64 encoding. i.e. '+' -> '-', '/' -> '_'.


see https://github.com/adobe/helix-pipeline-service/issues/282