### PR TITLE
fix: don't pin helix-fetch and universal for better deduping

### DIFF
--- a/packages/helix-shared-body-data/.renovaterc.json
+++ b/packages/helix-shared-body-data/.renovaterc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["github>adobe/helix-shared"],
+  "packageRules": [
+    {
+      "packageNames": ["@adobe/helix-fetch"],
+      "pin": false
+    },
+    {
+      "packageNames": ["@adobe/helix-universal"],
+      "pin": false
+    }
+  ]
+}

--- a/packages/helix-shared-body-data/package-lock.json
+++ b/packages/helix-shared-body-data/package-lock.json
@@ -6,17 +6,17 @@
   "packages": {
     "": {
       "name": "@adobe/helix-shared-body-data",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/helix-fetch": "3.0.3",
-        "@adobe/helix-shared-wrap": "^1.0.1"
+        "@adobe/helix-fetch": "^3.0.3",
+        "@adobe/helix-shared-wrap": "^1.0.2"
       },
       "devDependencies": {
         "mocha": "9.2.0"
       },
       "optionalDependencies": {
-        "@adobe/helix-universal": "3.0.4"
+        "@adobe/helix-universal": "^3.0.4"
       }
     },
     "node_modules/@adobe/helix-fetch": {
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@adobe/helix-shared-wrap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.1.tgz",
-      "integrity": "sha512-LkDX1p2IiutqxbSSjWo0mbVszAPcQLXogiOzDbxvYItAjLXL5FyItJbOYH5zKoM/qJCWN7uQw402MQ1+dUcM8g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.2.tgz",
+      "integrity": "sha512-IjsF6V4kqh/nj5QZ2VtCNIHNnRgs+xZgx+nK3OJ1dk1/IeQGVj9yEvCRhyeDUSYOJkVZM8TNVJ1L4fVwODh16g=="
     },
     "node_modules/@adobe/helix-universal": {
       "version": "3.0.4",
@@ -993,9 +993,9 @@
       }
     },
     "@adobe/helix-shared-wrap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.1.tgz",
-      "integrity": "sha512-LkDX1p2IiutqxbSSjWo0mbVszAPcQLXogiOzDbxvYItAjLXL5FyItJbOYH5zKoM/qJCWN7uQw402MQ1+dUcM8g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.2.tgz",
+      "integrity": "sha512-IjsF6V4kqh/nj5QZ2VtCNIHNnRgs+xZgx+nK3OJ1dk1/IeQGVj9yEvCRhyeDUSYOJkVZM8TNVJ1L4fVwODh16g=="
     },
     "@adobe/helix-universal": {
       "version": "3.0.4",

--- a/packages/helix-shared-body-data/package.json
+++ b/packages/helix-shared-body-data/package.json
@@ -23,11 +23,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/helix-fetch": "3.0.3",
+    "@adobe/helix-fetch": "^3.0.3",
     "@adobe/helix-shared-wrap": "^1.0.2"
   },
   "optionalDependencies": {
-    "@adobe/helix-universal": "3.0.4"
+    "@adobe/helix-universal": "^3.0.4"
   },
   "devDependencies": {
     "mocha": "9.2.0"

--- a/packages/helix-shared-bounce/.renovaterc.json
+++ b/packages/helix-shared-bounce/.renovaterc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["github>adobe/helix-shared"],
+  "packageRules": [
+    {
+      "packageNames": ["@adobe/helix-fetch"],
+      "pin": false
+    },
+    {
+      "packageNames": ["@adobe/helix-universal"],
+      "pin": false
+    }
+  ]
+}

--- a/packages/helix-shared-bounce/package-lock.json
+++ b/packages/helix-shared-bounce/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@adobe/helix-shared-bounce",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/helix-fetch": "3.0.3",
-        "@adobe/helix-shared-wrap": "^1.0.1"
+        "@adobe/helix-fetch": "^3.0.3",
+        "@adobe/helix-shared-wrap": "^1.0.2"
       },
       "devDependencies": {
         "mocha": "9.2.0",
@@ -18,7 +18,7 @@
         "proxyquire": "2.1.3"
       },
       "optionalDependencies": {
-        "@adobe/helix-universal": "3.0.4"
+        "@adobe/helix-universal": "^3.0.4"
       }
     },
     "node_modules/@adobe/helix-fetch": {
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@adobe/helix-shared-wrap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.1.tgz",
-      "integrity": "sha512-LkDX1p2IiutqxbSSjWo0mbVszAPcQLXogiOzDbxvYItAjLXL5FyItJbOYH5zKoM/qJCWN7uQw402MQ1+dUcM8g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.2.tgz",
+      "integrity": "sha512-IjsF6V4kqh/nj5QZ2VtCNIHNnRgs+xZgx+nK3OJ1dk1/IeQGVj9yEvCRhyeDUSYOJkVZM8TNVJ1L4fVwODh16g=="
     },
     "node_modules/@adobe/helix-universal": {
       "version": "3.0.4",
@@ -1144,9 +1144,9 @@
       }
     },
     "@adobe/helix-shared-wrap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.1.tgz",
-      "integrity": "sha512-LkDX1p2IiutqxbSSjWo0mbVszAPcQLXogiOzDbxvYItAjLXL5FyItJbOYH5zKoM/qJCWN7uQw402MQ1+dUcM8g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.2.tgz",
+      "integrity": "sha512-IjsF6V4kqh/nj5QZ2VtCNIHNnRgs+xZgx+nK3OJ1dk1/IeQGVj9yEvCRhyeDUSYOJkVZM8TNVJ1L4fVwODh16g=="
     },
     "@adobe/helix-universal": {
       "version": "3.0.4",

--- a/packages/helix-shared-bounce/package.json
+++ b/packages/helix-shared-bounce/package.json
@@ -23,11 +23,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/helix-fetch": "3.0.3",
+    "@adobe/helix-fetch": "^3.0.3",
     "@adobe/helix-shared-wrap": "^1.0.2"
   },
   "optionalDependencies": {
-    "@adobe/helix-universal": "3.0.4"
+    "@adobe/helix-universal": "^3.0.4"
   },
   "devDependencies": {
     "mocha": "9.2.0",

--- a/packages/helix-shared-config/.renovaterc.json
+++ b/packages/helix-shared-config/.renovaterc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["github>adobe/helix-shared"],
+  "packageRules": [
+    {
+      "packageNames": ["@adobe/helix-fetch"],
+      "pin": false
+    },
+    {
+      "packageNames": ["@adobe/helix-universal"],
+      "pin": false
+    }
+  ]
+}

--- a/packages/helix-shared-config/package-lock.json
+++ b/packages/helix-shared-config/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "@adobe/helix-shared-config",
-      "version": "1.7.7",
+      "version": "1.7.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/helix-fetch": "3.0.3",
-        "@adobe/helix-shared-git": "^1.1.1",
-        "@adobe/helix-shared-prune": "^1.0.1",
-        "@adobe/helix-shared-utils": "^2.0.1",
+        "@adobe/helix-fetch": "^3.0.3",
+        "@adobe/helix-shared-git": "^1.1.2",
+        "@adobe/helix-shared-prune": "^1.0.2",
+        "@adobe/helix-shared-utils": "^2.0.2",
         "ajv": "8.10.0",
         "ajv-formats": "2.1.1",
         "cookie": "0.4.2",
@@ -24,7 +24,7 @@
         "yaml": "1.10.2"
       },
       "devDependencies": {
-        "@adobe/helix-shared-wrap": "^1.0.1",
+        "@adobe/helix-shared-wrap": "^1.0.2",
         "@adobe/helix-testutils": "0.4.11",
         "@pollyjs/adapter-node-http": "6.0.4",
         "@pollyjs/core": "6.0.4",
@@ -58,28 +58,32 @@
       }
     },
     "node_modules/@adobe/helix-shared-git": {
-      "version": "1.1.1",
-      "license": "Apache-2.0",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-git/-/helix-shared-git-1.1.2.tgz",
+      "integrity": "sha512-MWhm2JXn0OaFb0KMt4R+M1/+3iKxL+JCHYEaWnwCtkEK3Z4UisF7G7/gOI3XwNzC+Azqu3ZDn9Qy4ROOstyOQw==",
       "dependencies": {
-        "@adobe/helix-shared-prune": "^1.0.1",
+        "@adobe/helix-shared-prune": "^1.0.2",
         "yaml": "1.10.2"
       }
     },
     "node_modules/@adobe/helix-shared-prune": {
-      "version": "1.0.1",
-      "license": "Apache-2.0"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-prune/-/helix-shared-prune-1.0.2.tgz",
+      "integrity": "sha512-dDpvCMy+GFbay9rA04Kw556TWGwNSDjFmy756ozeiKIzZ6p9lX4J/azcuAbP87o/fHyIjGjt5zJjbm3tbGldmw=="
     },
     "node_modules/@adobe/helix-shared-utils": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.2.tgz",
+      "integrity": "sha512-wSCVqHwBlspgX3i6v6JmRkc+eyjvQuUq6X48D8eKskYeKWk76M30TN3V2i3PmXdfVD1BbdFBF5xmcf6s9PiiOA==",
       "engines": {
         "node": ">= 14.17"
       }
     },
     "node_modules/@adobe/helix-shared-wrap": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "Apache-2.0"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.2.tgz",
+      "integrity": "sha512-IjsF6V4kqh/nj5QZ2VtCNIHNnRgs+xZgx+nK3OJ1dk1/IeQGVj9yEvCRhyeDUSYOJkVZM8TNVJ1L4fVwODh16g==",
+      "dev": true
     },
     "node_modules/@adobe/helix-testutils": {
       "version": "0.4.11",
@@ -2233,20 +2237,28 @@
       }
     },
     "@adobe/helix-shared-git": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-git/-/helix-shared-git-1.1.2.tgz",
+      "integrity": "sha512-MWhm2JXn0OaFb0KMt4R+M1/+3iKxL+JCHYEaWnwCtkEK3Z4UisF7G7/gOI3XwNzC+Azqu3ZDn9Qy4ROOstyOQw==",
       "requires": {
-        "@adobe/helix-shared-prune": "^1.0.1",
+        "@adobe/helix-shared-prune": "^1.0.2",
         "yaml": "1.10.2"
       }
     },
     "@adobe/helix-shared-prune": {
-      "version": "1.0.1"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-prune/-/helix-shared-prune-1.0.2.tgz",
+      "integrity": "sha512-dDpvCMy+GFbay9rA04Kw556TWGwNSDjFmy756ozeiKIzZ6p9lX4J/azcuAbP87o/fHyIjGjt5zJjbm3tbGldmw=="
     },
     "@adobe/helix-shared-utils": {
-      "version": "2.0.1"
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.2.tgz",
+      "integrity": "sha512-wSCVqHwBlspgX3i6v6JmRkc+eyjvQuUq6X48D8eKskYeKWk76M30TN3V2i3PmXdfVD1BbdFBF5xmcf6s9PiiOA=="
     },
     "@adobe/helix-shared-wrap": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.2.tgz",
+      "integrity": "sha512-IjsF6V4kqh/nj5QZ2VtCNIHNnRgs+xZgx+nK3OJ1dk1/IeQGVj9yEvCRhyeDUSYOJkVZM8TNVJ1L4fVwODh16g==",
       "dev": true
     },
     "@adobe/helix-testutils": {

--- a/packages/helix-shared-config/package.json
+++ b/packages/helix-shared-config/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/helix-fetch": "3.0.3",
+    "@adobe/helix-fetch": "^3.0.3",
     "@adobe/helix-shared-git": "^1.1.2",
     "@adobe/helix-shared-prune": "^1.0.2",
     "@adobe/helix-shared-utils": "^2.0.2",

--- a/packages/helix-shared-ims/.renovaterc.json
+++ b/packages/helix-shared-ims/.renovaterc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["github>adobe/helix-shared"],
+  "packageRules": [
+    {
+      "packageNames": ["@adobe/helix-fetch"],
+      "pin": false
+    },
+    {
+      "packageNames": ["@adobe/helix-universal"],
+      "pin": false
+    }
+  ]
+}

--- a/packages/helix-shared-ims/package-lock.json
+++ b/packages/helix-shared-ims/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "@adobe/helix-shared-ims",
-      "version": "1.2.17",
+      "version": "1.2.18",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/helix-fetch": "3.0.3",
-        "@adobe/helix-shared-body-data": "^1.1.12",
-        "@adobe/helix-shared-utils": "^2.0.1",
-        "@adobe/helix-shared-wrap": "^1.0.1",
+        "@adobe/helix-fetch": "^3.0.3",
+        "@adobe/helix-shared-body-data": "^1.1.13",
+        "@adobe/helix-shared-utils": "^2.0.2",
+        "@adobe/helix-shared-wrap": "^1.0.2",
         "cookie": "0.4.2"
       },
       "devDependencies": {
@@ -20,7 +20,7 @@
         "nock": "13.2.4"
       },
       "optionalDependencies": {
-        "@adobe/helix-universal": "3.0.4"
+        "@adobe/helix-universal": "^3.0.4"
       }
     },
     "node_modules/@adobe/helix-fetch": {
@@ -37,51 +37,29 @@
       }
     },
     "node_modules/@adobe/helix-shared-body-data": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-1.1.12.tgz",
-      "integrity": "sha512-ry6W+puRcSh+4Y9z9OnFyNVQ68H6V3xGXEHWFtjTX1BJ4uL2qJnl69Vl24vs5A0qr1lU2KqtN4153niKTerBrA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-1.1.13.tgz",
+      "integrity": "sha512-cigik2jKhlCt/WHLGnY7cZJRe6UsVfNC3bTMvJr/Hq8QVwG7NN643x/ProjjpMthEMabXCbWklZynmlD4+wX5A==",
       "dependencies": {
-        "@adobe/helix-fetch": "3.0.2",
-        "@adobe/helix-shared-wrap": "^1.0.1"
+        "@adobe/helix-fetch": "3.0.3",
+        "@adobe/helix-shared-wrap": "^1.0.2"
       },
       "optionalDependencies": {
-        "@adobe/helix-universal": "3.0.3"
-      }
-    },
-    "node_modules/@adobe/helix-shared-body-data/node_modules/@adobe/helix-fetch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-fetch/-/helix-fetch-3.0.2.tgz",
-      "integrity": "sha512-5fwBSUShA+93LKKeLmdbw8tEYeEKYHtTad07QYxHmmcPviSh1JNA+pv9b+jK1p+EU3fjud8nr+prqwG3l4J+eg==",
-      "dependencies": {
-        "debug": "4.3.3",
-        "http-cache-semantics": "4.1.0",
-        "lru-cache": "6.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/@adobe/helix-shared-body-data/node_modules/@adobe/helix-universal": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-3.0.3.tgz",
-      "integrity": "sha512-VVbLfkIlidVXurvidTD7AfskFkhj20yH6KJxzSY7f80at5MN8hcDAHn2AAL7ScPJzAhAlTIQkhFGpL0rV4M6/w==",
-      "optional": true,
-      "dependencies": {
-        "@adobe/helix-fetch": "3.0.2"
+        "@adobe/helix-universal": "3.0.4"
       }
     },
     "node_modules/@adobe/helix-shared-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.1.tgz",
-      "integrity": "sha512-t+e7YbO0wZnSdO95E2oi/cXZ/eGdto7cQuEGOkxAZmgBPBRoFgxGyCNCwCRES6UaZetAtDKQpED1ZZJbwR29FA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.2.tgz",
+      "integrity": "sha512-wSCVqHwBlspgX3i6v6JmRkc+eyjvQuUq6X48D8eKskYeKWk76M30TN3V2i3PmXdfVD1BbdFBF5xmcf6s9PiiOA==",
       "engines": {
         "node": ">= 14.17"
       }
     },
     "node_modules/@adobe/helix-shared-wrap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.1.tgz",
-      "integrity": "sha512-LkDX1p2IiutqxbSSjWo0mbVszAPcQLXogiOzDbxvYItAjLXL5FyItJbOYH5zKoM/qJCWN7uQw402MQ1+dUcM8g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.2.tgz",
+      "integrity": "sha512-IjsF6V4kqh/nj5QZ2VtCNIHNnRgs+xZgx+nK3OJ1dk1/IeQGVj9yEvCRhyeDUSYOJkVZM8TNVJ1L4fVwODh16g=="
     },
     "node_modules/@adobe/helix-universal": {
       "version": "3.0.4",
@@ -1086,45 +1064,24 @@
       }
     },
     "@adobe/helix-shared-body-data": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-1.1.12.tgz",
-      "integrity": "sha512-ry6W+puRcSh+4Y9z9OnFyNVQ68H6V3xGXEHWFtjTX1BJ4uL2qJnl69Vl24vs5A0qr1lU2KqtN4153niKTerBrA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-1.1.13.tgz",
+      "integrity": "sha512-cigik2jKhlCt/WHLGnY7cZJRe6UsVfNC3bTMvJr/Hq8QVwG7NN643x/ProjjpMthEMabXCbWklZynmlD4+wX5A==",
       "requires": {
-        "@adobe/helix-fetch": "3.0.2",
-        "@adobe/helix-shared-wrap": "^1.0.1",
-        "@adobe/helix-universal": "3.0.3"
-      },
-      "dependencies": {
-        "@adobe/helix-fetch": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@adobe/helix-fetch/-/helix-fetch-3.0.2.tgz",
-          "integrity": "sha512-5fwBSUShA+93LKKeLmdbw8tEYeEKYHtTad07QYxHmmcPviSh1JNA+pv9b+jK1p+EU3fjud8nr+prqwG3l4J+eg==",
-          "requires": {
-            "debug": "4.3.3",
-            "http-cache-semantics": "4.1.0",
-            "lru-cache": "6.0.0"
-          }
-        },
-        "@adobe/helix-universal": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-3.0.3.tgz",
-          "integrity": "sha512-VVbLfkIlidVXurvidTD7AfskFkhj20yH6KJxzSY7f80at5MN8hcDAHn2AAL7ScPJzAhAlTIQkhFGpL0rV4M6/w==",
-          "optional": true,
-          "requires": {
-            "@adobe/helix-fetch": "3.0.2"
-          }
-        }
+        "@adobe/helix-fetch": "3.0.3",
+        "@adobe/helix-shared-wrap": "^1.0.2",
+        "@adobe/helix-universal": "3.0.4"
       }
     },
     "@adobe/helix-shared-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.1.tgz",
-      "integrity": "sha512-t+e7YbO0wZnSdO95E2oi/cXZ/eGdto7cQuEGOkxAZmgBPBRoFgxGyCNCwCRES6UaZetAtDKQpED1ZZJbwR29FA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.2.tgz",
+      "integrity": "sha512-wSCVqHwBlspgX3i6v6JmRkc+eyjvQuUq6X48D8eKskYeKWk76M30TN3V2i3PmXdfVD1BbdFBF5xmcf6s9PiiOA=="
     },
     "@adobe/helix-shared-wrap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.1.tgz",
-      "integrity": "sha512-LkDX1p2IiutqxbSSjWo0mbVszAPcQLXogiOzDbxvYItAjLXL5FyItJbOYH5zKoM/qJCWN7uQw402MQ1+dUcM8g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.2.tgz",
+      "integrity": "sha512-IjsF6V4kqh/nj5QZ2VtCNIHNnRgs+xZgx+nK3OJ1dk1/IeQGVj9yEvCRhyeDUSYOJkVZM8TNVJ1L4fVwODh16g=="
     },
     "@adobe/helix-universal": {
       "version": "3.0.4",

--- a/packages/helix-shared-ims/package.json
+++ b/packages/helix-shared-ims/package.json
@@ -29,14 +29,14 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/helix-fetch": "3.0.3",
+    "@adobe/helix-fetch": "^3.0.3",
     "@adobe/helix-shared-body-data": "^1.1.13",
     "@adobe/helix-shared-utils": "^2.0.2",
     "@adobe/helix-shared-wrap": "^1.0.2",
     "cookie": "0.4.2"
   },
   "optionalDependencies": {
-    "@adobe/helix-universal": "3.0.4"
+    "@adobe/helix-universal": "^3.0.4"
   },
   "devDependencies": {
     "mocha": "9.2.0",

--- a/packages/helix-shared-indexer/.renovaterc.json
+++ b/packages/helix-shared-indexer/.renovaterc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["github>adobe/helix-shared"],
+  "packageRules": [
+    {
+      "packageNames": ["@adobe/helix-fetch"],
+      "pin": false
+    },
+    {
+      "packageNames": ["@adobe/helix-universal"],
+      "pin": false
+    }
+  ]
+}

--- a/packages/helix-shared-indexer/package-lock.json
+++ b/packages/helix-shared-indexer/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@adobe/helix-shared-indexer",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "Apache-2.0",
       "dependencies": {
         "jsdom": "19.0.0",
@@ -15,8 +15,8 @@
         "moment": "2.29.1"
       },
       "devDependencies": {
-        "@adobe/helix-fetch": "3.0.3",
-        "@adobe/helix-shared-config": "^1.7.7",
+        "@adobe/helix-fetch": "^3.0.3",
+        "@adobe/helix-shared-config": "^1.7.8",
         "mocha": "9.2.0"
       }
     },
@@ -35,17 +35,18 @@
       }
     },
     "node_modules/@adobe/helix-shared-config": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-config/-/helix-shared-config-1.7.7.tgz",
-      "integrity": "sha512-dgywICk6Fx4P1gg23ITHWiBtQj2spsdg4CGcE2U3OvabP2LIyVpedSTw5YV6D17HWnU+/CH1fHI4+FTNLiJpmA==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-config/-/helix-shared-config-1.7.8.tgz",
+      "integrity": "sha512-hrS4smLMlwXaWQva7vdjbEjhc75pN2c00jG0rDY3t7HPufj/3bW3FHKGY3Txu8vu7ZDv5B2EYjJnn6ZWSgbwtA==",
       "dev": true,
       "dependencies": {
-        "@adobe/helix-fetch": "3.0.2",
-        "@adobe/helix-shared-git": "^1.1.1",
-        "@adobe/helix-shared-prune": "^1.0.1",
-        "@adobe/helix-shared-utils": "^2.0.1",
-        "ajv": "8.9.0",
+        "@adobe/helix-fetch": "3.0.3",
+        "@adobe/helix-shared-git": "^1.1.2",
+        "@adobe/helix-shared-prune": "^1.0.2",
+        "@adobe/helix-shared-utils": "^2.0.2",
+        "ajv": "8.10.0",
         "ajv-formats": "2.1.1",
+        "cookie": "0.4.2",
         "fs-extra": "10.0.0",
         "ignore": "5.2.0",
         "lru-cache": "6.0.0",
@@ -54,40 +55,26 @@
         "yaml": "1.10.2"
       }
     },
-    "node_modules/@adobe/helix-shared-config/node_modules/@adobe/helix-fetch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-fetch/-/helix-fetch-3.0.2.tgz",
-      "integrity": "sha512-5fwBSUShA+93LKKeLmdbw8tEYeEKYHtTad07QYxHmmcPviSh1JNA+pv9b+jK1p+EU3fjud8nr+prqwG3l4J+eg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4.3.3",
-        "http-cache-semantics": "4.1.0",
-        "lru-cache": "6.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/@adobe/helix-shared-git": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-git/-/helix-shared-git-1.1.1.tgz",
-      "integrity": "sha512-Dz8tpLBVvI/4XBl1v8AxcXOjOz5opRbGVmbh8zShW0uVw6/GJgLrSsXbiCJgVVy3cv3lW4jvXV9YdmyZyXcqBA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-git/-/helix-shared-git-1.1.2.tgz",
+      "integrity": "sha512-MWhm2JXn0OaFb0KMt4R+M1/+3iKxL+JCHYEaWnwCtkEK3Z4UisF7G7/gOI3XwNzC+Azqu3ZDn9Qy4ROOstyOQw==",
       "dev": true,
       "dependencies": {
-        "@adobe/helix-shared-prune": "^1.0.1",
+        "@adobe/helix-shared-prune": "^1.0.2",
         "yaml": "1.10.2"
       }
     },
     "node_modules/@adobe/helix-shared-prune": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-prune/-/helix-shared-prune-1.0.1.tgz",
-      "integrity": "sha512-3A4V/AsMKmXOFNIanFuuLLamsoMxuVM2BZF0ffJcQP1VtolD/iWY5cSXWJfQzkwVlsg+97eccSeZWOipF/wKFA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-prune/-/helix-shared-prune-1.0.2.tgz",
+      "integrity": "sha512-dDpvCMy+GFbay9rA04Kw556TWGwNSDjFmy756ozeiKIzZ6p9lX4J/azcuAbP87o/fHyIjGjt5zJjbm3tbGldmw==",
       "dev": true
     },
     "node_modules/@adobe/helix-shared-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.1.tgz",
-      "integrity": "sha512-t+e7YbO0wZnSdO95E2oi/cXZ/eGdto7cQuEGOkxAZmgBPBRoFgxGyCNCwCRES6UaZetAtDKQpED1ZZJbwR29FA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.2.tgz",
+      "integrity": "sha512-wSCVqHwBlspgX3i6v6JmRkc+eyjvQuUq6X48D8eKskYeKWk76M30TN3V2i3PmXdfVD1BbdFBF5xmcf6s9PiiOA==",
       "dev": true,
       "engines": {
         "node": ">= 14.17"
@@ -163,9 +150,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -411,6 +398,15 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -1762,58 +1758,46 @@
       }
     },
     "@adobe/helix-shared-config": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-config/-/helix-shared-config-1.7.7.tgz",
-      "integrity": "sha512-dgywICk6Fx4P1gg23ITHWiBtQj2spsdg4CGcE2U3OvabP2LIyVpedSTw5YV6D17HWnU+/CH1fHI4+FTNLiJpmA==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-config/-/helix-shared-config-1.7.8.tgz",
+      "integrity": "sha512-hrS4smLMlwXaWQva7vdjbEjhc75pN2c00jG0rDY3t7HPufj/3bW3FHKGY3Txu8vu7ZDv5B2EYjJnn6ZWSgbwtA==",
       "dev": true,
       "requires": {
-        "@adobe/helix-fetch": "3.0.2",
-        "@adobe/helix-shared-git": "^1.1.1",
-        "@adobe/helix-shared-prune": "^1.0.1",
-        "@adobe/helix-shared-utils": "^2.0.1",
-        "ajv": "8.9.0",
+        "@adobe/helix-fetch": "3.0.3",
+        "@adobe/helix-shared-git": "^1.1.2",
+        "@adobe/helix-shared-prune": "^1.0.2",
+        "@adobe/helix-shared-utils": "^2.0.2",
+        "ajv": "8.10.0",
         "ajv-formats": "2.1.1",
+        "cookie": "0.4.2",
         "fs-extra": "10.0.0",
         "ignore": "5.2.0",
         "lru-cache": "6.0.0",
         "object-hash": "2.2.0",
         "uri-js": "4.4.1",
         "yaml": "1.10.2"
-      },
-      "dependencies": {
-        "@adobe/helix-fetch": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@adobe/helix-fetch/-/helix-fetch-3.0.2.tgz",
-          "integrity": "sha512-5fwBSUShA+93LKKeLmdbw8tEYeEKYHtTad07QYxHmmcPviSh1JNA+pv9b+jK1p+EU3fjud8nr+prqwG3l4J+eg==",
-          "dev": true,
-          "requires": {
-            "debug": "4.3.3",
-            "http-cache-semantics": "4.1.0",
-            "lru-cache": "6.0.0"
-          }
-        }
       }
     },
     "@adobe/helix-shared-git": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-git/-/helix-shared-git-1.1.1.tgz",
-      "integrity": "sha512-Dz8tpLBVvI/4XBl1v8AxcXOjOz5opRbGVmbh8zShW0uVw6/GJgLrSsXbiCJgVVy3cv3lW4jvXV9YdmyZyXcqBA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-git/-/helix-shared-git-1.1.2.tgz",
+      "integrity": "sha512-MWhm2JXn0OaFb0KMt4R+M1/+3iKxL+JCHYEaWnwCtkEK3Z4UisF7G7/gOI3XwNzC+Azqu3ZDn9Qy4ROOstyOQw==",
       "dev": true,
       "requires": {
-        "@adobe/helix-shared-prune": "^1.0.1",
+        "@adobe/helix-shared-prune": "^1.0.2",
         "yaml": "1.10.2"
       }
     },
     "@adobe/helix-shared-prune": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-prune/-/helix-shared-prune-1.0.1.tgz",
-      "integrity": "sha512-3A4V/AsMKmXOFNIanFuuLLamsoMxuVM2BZF0ffJcQP1VtolD/iWY5cSXWJfQzkwVlsg+97eccSeZWOipF/wKFA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-prune/-/helix-shared-prune-1.0.2.tgz",
+      "integrity": "sha512-dDpvCMy+GFbay9rA04Kw556TWGwNSDjFmy756ozeiKIzZ6p9lX4J/azcuAbP87o/fHyIjGjt5zJjbm3tbGldmw==",
       "dev": true
     },
     "@adobe/helix-shared-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.1.tgz",
-      "integrity": "sha512-t+e7YbO0wZnSdO95E2oi/cXZ/eGdto7cQuEGOkxAZmgBPBRoFgxGyCNCwCRES6UaZetAtDKQpED1ZZJbwR29FA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-2.0.2.tgz",
+      "integrity": "sha512-wSCVqHwBlspgX3i6v6JmRkc+eyjvQuUq6X48D8eKskYeKWk76M30TN3V2i3PmXdfVD1BbdFBF5xmcf6s9PiiOA==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -1867,9 +1851,9 @@
       }
     },
     "ajv": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -2051,6 +2035,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
     },
     "cssom": {

--- a/packages/helix-shared-indexer/package.json
+++ b/packages/helix-shared-indexer/package.json
@@ -29,7 +29,7 @@
     "moment": "2.29.1"
   },
   "devDependencies": {
-    "@adobe/helix-fetch": "3.0.3",
+    "@adobe/helix-fetch": "^3.0.3",
     "@adobe/helix-shared-config": "^1.7.8",
     "mocha": "9.2.0"
   }


### PR DESCRIPTION
uses the `^` version for helix-fetch and universal, thus allowing upstream projects to better dedupe them. this can prevent errors where `instanceof` checks otherwise fail.
