### PR TITLE
feat: add support for debounce function

### DIFF
--- a/packages/helix-shared-bounce/README.md
+++ b/packages/helix-shared-bounce/README.md
@@ -22,6 +22,25 @@
    .with(bounce, { responder: fast });
  ```
 
+## Disabling Bouncing for certain requests
+
+The plugin options can take a `debounce` function property that is called with the `request` and
+`context`. if it returns a non falsy value the wrapped function will not be bounced.
+
+```js
+
+function debounce(req, context) {
+  if (context.pathInfo.suffix === '/about') {
+    return true;
+  }
+  return false;
+}
+
+module.exports.main = wrap(main)
+   .with(bounce, { responder: fast, debounce });
+ 
+```
+
 ## Disabling Bouncing for Tests
 
 If you are testing a function that is using `bounce` locally, you might want to disable the bouncing for the duration of the test, because you would otherwise have

--- a/packages/helix-shared-bounce/src/bounce.js
+++ b/packages/helix-shared-bounce/src/bounce.js
@@ -20,9 +20,11 @@ const timer = {
   setTimeout: async (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
 };
 
-function bounce(func, { responder, timeout = 500 }) {
+function bounce(func, { responder, timeout = 500, debounce = () => '' }) {
   return async (request, context) => {
-    const id = request.headers.get('x-hlx-bounce-id') || process.env.HELIX_DEBOUNCE;
+    const id = request.headers.get('x-hlx-bounce-id')
+      || process.env.HELIX_DEBOUNCE
+      || debounce(request, context);
     if (id) {
       // use the provided bounce id
       context.invocation = context.invocation || {};


### PR DESCRIPTION

## Disabling Bouncing for certain requests

The plugin options can take a `debounce` function property that is called with the `request` and
`context`. if it returns a non falsy value the wrapped function will not be bounced.

```js

function debounce(req, context) {
  if (context.pathInfo.suffix === '/about') {
    return true;
  }
  return false;
}

module.exports.main = wrap(main)
   .with(bounce, { responder: fast, debounce });
 
```