### PR TITLE
fix: suppress deprecation warning (maxAge has been replaced by ttl)

### DIFF
--- a/packages/helix-shared-config/src/fetchconfig/cache.js
+++ b/packages/helix-shared-config/src/fetchconfig/cache.js
@@ -12,7 +12,7 @@
 
 const LRU = require('lru-cache');
 
-let lru = new LRU({ max: 1000, maxAge: 60 * 1000 });
+let lru = new LRU({ max: 1000, ttl: 60 * 1000 });
 
 /**
  * Returns a memoized version of the function `fn`.


### PR DESCRIPTION
Causes a line being logged when starting a debugging session:
```
(node:11906) [LRU_CACHE_OPTION_maxAge] DeprecationWarning: The maxAge option is deprecated. Please use options.ttl instead.
```

see: https://www.npmjs.com/package/lru-cache/v/7.8.2#ttl