### PR TITLE
feat: replace index definition

### DIFF
--- a/packages/helix-shared-config/src/IndexConfig.js
+++ b/packages/helix-shared-config/src/IndexConfig.js
@@ -64,6 +64,31 @@ class IndexConfig extends SchemaDerivedConfig {
   }
 
   /**
+   * Replaces an index definition.
+   *
+   * @param {Object} index index configuration
+   * @param {string} index.name index name
+   * @param {Array} index.include paths to include
+   * @param {Array} index.exclude paths to exclude
+   * @param {string} index.target target
+   * @param {object} index.properties properties to add to the index
+   */
+  replaceIndex({
+    name, include, exclude, target, properties,
+  }) {
+    const { indices } = this._cfg;
+    indices[name] = {
+      include,
+      exclude,
+      target,
+      properties,
+    };
+
+    // let BaseConfig.toYAML() use the JSON output
+    this._document = null;
+  }
+
+  /**
    * Evaluates a variable expression
    * @param {string} expression the expression to encode
    * @param {string[]} parameters the list of variable parameters in the query

--- a/packages/helix-shared-config/test/indexconfigs.test.js
+++ b/packages/helix-shared-config/test/indexconfigs.test.js
@@ -210,6 +210,42 @@ describe('Index Config Loading', () => {
     assert.deepStrictEqual(property.value, index.properties.author.value);
   });
 
+  it('replace index configuration', async () => {
+    const cfg = new IndexConfig()
+      .withConfigPath(path.resolve(SPEC_ROOT, 'query.yaml'));
+    await cfg.init();
+
+    const index = {
+      name: 'blog-posts',
+      include: ['/en/publish/*/*/*/*'],
+      exclude: ['**/Document.*'],
+      target: '/query-index.json',
+      properties: {
+        author: {
+          select: 'head > meta[name="author"]',
+          value: 'attribute(el, \'content\')',
+        },
+      },
+    };
+    cfg.replaceIndex(index);
+
+    // reparse the modified configuration's YAML output
+    const newcfg = new IndexConfig()
+      .withSource(cfg.toYAML());
+    await newcfg.init();
+
+    const config = newcfg.indices.find((i) => i.name === index.name);
+    assert.notStrictEqual(config, null);
+    assert.deepStrictEqual(config.include, index.include);
+    assert.deepStrictEqual(config.exclude, index.exclude);
+    assert.deepStrictEqual(config.target, index.target);
+
+    const property = config.properties.find((p) => p.name === 'author');
+    assert.notStrictEqual(property, null);
+    assert.deepStrictEqual(property.select, index.properties.author.select);
+    assert.deepStrictEqual(property.value, index.properties.author.value);
+  });
+
   it('add index configuration with existing name', async () => {
     const cfg = new IndexConfig()
       .withConfigPath(path.resolve(SPEC_ROOT, 'query.yaml'));


### PR DESCRIPTION
Allows replacing an index definition (e.g. to add or remove properties)