### PR TITLE
fix: match should enforce array input

### DIFF
--- a/packages/helix-shared-indexer/src/index-resource.js
+++ b/packages/helix-shared-indexer/src/index-resource.js
@@ -58,6 +58,11 @@ const helpers = {
     // todo: maybe base on function ?
     const result = [];
     const regex = new RegExp(re, 'g');
+
+    if (!Array.isArray(elements)) {
+      // eslint-disable-next-line no-param-reassign
+      elements = [elements];
+    }
     elements.forEach((el) => {
       let m;
       const content = typeof el === 'string' ? el : toText(el);
@@ -77,6 +82,7 @@ const helpers = {
     return [text.split(/\s+/g).slice(start, end).join(' ')];
   },
   replace: (s, searchValue, replaceValue) => [s.replace(searchValue, replaceValue)],
+  replaceAll: (s, searchValue, replaceValue) => [s.replaceAll(searchValue, replaceValue)],
 };
 
 function evaluate(expression, context) {

--- a/packages/helix-shared-indexer/test/index-resource.test.js
+++ b/packages/helix-shared-indexer/test/index-resource.test.js
@@ -174,6 +174,7 @@ describe('Index Resource Tests', () => {
       'missing-header': '',
       'non-array-words': 'Mon, 22 Feb 2021 15:28:00 GMT',
       paragraph: '\n    <p>consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</p>\n  ',
+      'first-segment': 'abc',
       'replace-path': '/zc/de/ab/fg/abcd',
       'replaceAll-path': '/zc/de/z/fg/zcd',
       sourceHash: 'JJYxCM1NDG4ahJm9f',

--- a/packages/helix-shared-indexer/test/index-resource.test.js
+++ b/packages/helix-shared-indexer/test/index-resource.test.js
@@ -44,10 +44,18 @@ indices:
         select: head > meta[name="x-source-hash"]
         value: |
           attribute(el, 'content')
-      external-path:
+      first-segment:
         select: none
         value: |
-          replace(path, '/test/specs/', '/')
+          match(path, '^/([^/]+)/')
+      replace-path:
+        select: none
+        value: |
+          replace(path, 'ab', 'z')
+      replaceAll-path:
+        select: none
+        value: |
+          replaceAll(path, 'ab', 'z')
       paragraph:
         select: main > div:nth-of-type(5)
         value: |
@@ -151,14 +159,13 @@ describe('Index Resource Tests', () => {
   it('indexing a resource', async () => {
     const config = await new IndexConfig().withSource(INDEX).init();
     const headers = new Headers({ 'last-modified': 'Mon, 22 Feb 2021 15:28:00 GMT' });
-    const record = indexResource('/path', { body: BODY, headers }, config.indices[0], console);
+    const record = indexResource('/abc/de/ab/fg/abcd', { body: BODY, headers }, config.indices[0], console);
     assert.deepEqual(record, {
       author: 'Max',
       'bad-selector': '',
       'call-unknown-function': '',
       'condition-unsupported': '',
       date: 44313,
-      'external-path': '/path',
       'last-modified': 1614007680,
       'last-modified-raw': 'Mon, 22 Feb 2021 15:28:00 GMT',
       'match-simple': '',
@@ -167,6 +174,8 @@ describe('Index Resource Tests', () => {
       'missing-header': '',
       'non-array-words': 'Mon, 22 Feb 2021 15:28:00 GMT',
       paragraph: '\n    <p>consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</p>\n  ',
+      'replace-path': '/zc/de/ab/fg/abcd',
+      'replaceAll-path': '/zc/de/z/fg/zcd',
       sourceHash: 'JJYxCM1NDG4ahJm9f',
       teaser: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua Ut',
       title: 'I feel good',


### PR DESCRIPTION
ensure arguments to `match` is an array