### PR TITLE
feat: support resolving secrets name via function

### DIFF
--- a/packages/helix-shared-secrets/src/secrets-wrapper.js
+++ b/packages/helix-shared-secrets/src/secrets-wrapper.js
@@ -30,19 +30,17 @@ const cache = {
  *
  * @param {SecretsOptions} opts - the options
  * @param {UniversalContext} ctx - the context
- * @param {string} defaultSecretsPath - the default secrets path
  * @return {Promise<string>} the secrets path
  */
-async function evaluatePathFromName(opts, ctx, defaultSecretsPath) {
-  let secretsPath;
+async function evaluatePathFromName(opts, ctx) {
+  let secretsPath = `/helix-deploy/${ctx.func.package}/${ctx.func.name}`;
 
   try {
     const userPath = typeof opts.name === 'function' ? await opts.name.call(ctx, opts) : opts.name;
-    secretsPath = userPath || defaultSecretsPath;
+    secretsPath = userPath || secretsPath;
   } catch (e) {
     const { log = console } = ctx;
     log.error(`error in user-supplied 'name' function: ${e.message}`);
-    secretsPath = defaultSecretsPath;
   }
 
   return secretsPath;
@@ -82,14 +80,12 @@ export async function loadSecrets(ctx, opts) {
     return {};
   }
 
-  const defaultSecretsPath = `/helix-deploy/${ctx.func.package}/${ctx.func.name}`;
-
   const {
     expiration = CACHE_EXPIRATION,
     checkDelay = CHECK_DELAY,
   } = opts;
 
-  const secretsPath = await evaluatePathFromName(opts, ctx, defaultSecretsPath);
+  const secretsPath = await evaluatePathFromName(opts, ctx);
 
   const sm = new SecretsManager(process.env);
   const now = Date.now();

--- a/packages/helix-shared-secrets/test/secrets-wrapper.test.js
+++ b/packages/helix-shared-secrets/test/secrets-wrapper.test.js
@@ -182,7 +182,11 @@ describe('Secrets Wrapper Unit Tests', () => {
         }];
       });
 
-    const nameFunction = () => '';
+    const nameFunction = (ctx, opts) => {
+      assert.deepStrictEqual(ctx, DEFAULT_CONTEXT());
+      assert.deepStrictEqual(opts, { name: nameFunction });
+      return '';
+    };
 
     const main = wrap((req, ctx) => {
       assert.deepStrictEqual(ctx.env, { SOME_SECRET: 'pssst' });

--- a/packages/helix-shared-secrets/test/secrets-wrapper.test.js
+++ b/packages/helix-shared-secrets/test/secrets-wrapper.test.js
@@ -170,6 +170,52 @@ describe('Secrets Wrapper Unit Tests', () => {
     assert.strictEqual(resp.status, 200);
   });
 
+  it('fetches secrets with default path if custom function returns empty', async () => {
+    nock('https://secretsmanager.us-east-1.amazonaws.com/')
+      .post('/')
+      .reply((uri, body) => {
+        assert.strictEqual(body, '{"SecretId":"/helix-deploy/helix3/helix-admin"}');
+        return [200, {
+          SecretString: JSON.stringify({ SOME_SECRET: 'pssst' }),
+        }, {
+          'content-type': 'application/json',
+        }];
+      });
+
+    const nameFunction = () => '';
+
+    const main = wrap((req, ctx) => {
+      assert.deepStrictEqual(ctx.env, { SOME_SECRET: 'pssst' });
+      return new Response(200);
+    }).with(secrets, { name: nameFunction });
+    const resp = await main(new Request('http://localhost'), DEFAULT_CONTEXT());
+    assert.strictEqual(resp.status, 200);
+  });
+
+  it('fetches secrets with default path if custom function throws error', async () => {
+    nock('https://secretsmanager.us-east-1.amazonaws.com/')
+      .post('/')
+      .reply((uri, body) => {
+        assert.strictEqual(body, '{"SecretId":"/helix-deploy/helix3/helix-admin"}');
+        return [200, {
+          SecretString: JSON.stringify({ SOME_SECRET: 'pssst' }),
+        }, {
+          'content-type': 'application/json',
+        }];
+      });
+
+    const nameFunction = () => {
+      throw new Error('boom');
+    };
+
+    const main = wrap((req, ctx) => {
+      assert.deepStrictEqual(ctx.env, { SOME_SECRET: 'pssst' });
+      return new Response(200);
+    }).with(secrets, { name: nameFunction });
+    const resp = await main(new Request('http://localhost'), DEFAULT_CONTEXT());
+    assert.strictEqual(resp.status, 200);
+  });
+
   it('caches secrets', async () => {
     nock('https://secretsmanager.us-east-1.amazonaws.com/')
       .post('/')


### PR DESCRIPTION
In some scenarios it may make sense to have the secrets path (name) as used by the wrapper be dynamically specified. One example is to dynamically set the secrets path (name) depending on the function version. This for example to distinguish secrets intended for production versus ones for development based on the function version (e.g. `ci` vs `v1`).

