### PR TITLE
chore: use version range for adobe/fetch

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,11 +2,14 @@
   "extends": [
     "config:base",
     ":semanticCommits",
-    ":autodetectPinVersions"
   ],
   "timezone": "Europe/Zurich",
   "branchPrefix": "renovate-",
   "packageRules": [
+    {
+      "matchPackageNames": ["@adobe/fetch"],
+      "rangeStrategy": "replace"
+    },
     {
       "matchPackageNames": ["eslint"],
       "allowedVersions": "<9.0.0"


### PR DESCRIPTION
see https://docs.renovatebot.com/configuration-options/#rangestrategy

we want adobe/fetch in the "libraries" to default to a version range, so that the users of the libraries can easier update