### PR TITLE
fix: check empty Account only with type 'onedrive'

### DIFF
--- a/packages/helix-shared-tokencache/src/MemCachePlugin.js
+++ b/packages/helix-shared-tokencache/src/MemCachePlugin.js
@@ -30,6 +30,7 @@ export class MemCachePlugin {
     this.log = opts.log || console;
     this.key = opts.key;
     this.base = opts.base;
+    this.type = opts.type;
     this.caches = opts.caches || caches;
   }
 
@@ -83,13 +84,13 @@ export class MemCachePlugin {
    * @param {TokenCacheContext} cacheContext
    */
   async afterCacheAccess(cacheContext) {
-    const { log } = this;
+    const { log, type } = this;
 
     if (!cacheContext.cacheHasChanged) {
       return false;
     }
     const data = JSON.parse(cacheContext.tokenCache.serialize());
-    if (Object.keys(data.Account ?? {}).length === 0) {
+    if (type === 'onedrive' && Object.keys(data.Account ?? {}).length === 0) {
       log.info('mem: write token cache done, ignoring empty data', this.key);
       return false;
     }

--- a/packages/helix-shared-tokencache/src/S3CachePlugin.js
+++ b/packages/helix-shared-tokencache/src/S3CachePlugin.js
@@ -40,6 +40,7 @@ export class S3CachePlugin {
     this.key = opts.key;
     this.secret = opts.secret;
     this.readOnly = opts.readOnly || false;
+    this.type = opts.type;
     this.s3 = new S3Client();
     this.meta = null;
     this.data = null;
@@ -140,7 +141,7 @@ export class S3CachePlugin {
   }
 
   async afterCacheAccess(cacheContext) {
-    const { log } = this;
+    const { log, type } = this;
 
     if (!cacheContext.cacheHasChanged) {
       return false;
@@ -149,7 +150,7 @@ export class S3CachePlugin {
       await this.#loadData();
     }
     const data = JSON.parse(cacheContext.tokenCache.serialize());
-    if (Object.keys(data.Account ?? {}).length === 0) {
+    if (type === 'onedrive' && Object.keys(data.Account ?? {}).length === 0) {
       log.info('s3: write token cache, ignoring empty data', this.key);
       return false;
     }

--- a/packages/helix-shared-tokencache/src/getCachePlugin.js
+++ b/packages/helix-shared-tokencache/src/getCachePlugin.js
@@ -79,6 +79,7 @@ export async function getCachePlugin(opts, type) {
     log,
     key: basePlugin.key,
     base: basePlugin,
+    type,
   };
   if (process.env.HELIX_ONEDRIVE_LOCAL_AUTH_CACHE) {
     cacheOpts.caches = new Map();

--- a/packages/helix-shared-tokencache/test/mem-cache-plugin.test.js
+++ b/packages/helix-shared-tokencache/test/mem-cache-plugin.test.js
@@ -115,6 +115,7 @@ describe('MemCachePlugin Test', () => {
       log: console,
       key: 'foobar-key',
       caches,
+      type: 'onedrive',
     });
 
     const ctx = new MockTokenCacheContext({
@@ -132,6 +133,7 @@ describe('MemCachePlugin Test', () => {
       log: console,
       key: 'foobar-key',
       caches,
+      type: 'onedrive',
     });
 
     const ctx = new MockTokenCacheContext({

--- a/packages/helix-shared-tokencache/test/s3-cache-plugin.test.js
+++ b/packages/helix-shared-tokencache/test/s3-cache-plugin.test.js
@@ -219,6 +219,7 @@ describe('S3CachePlugin Test', () => {
       bucket: 'test-bucket',
       key: 'myproject/auth-default/json',
       secret: '',
+      type: 'onedrive',
     });
 
     nock('https://test-bucket.s3.us-east-1.amazonaws.com')
@@ -240,6 +241,7 @@ describe('S3CachePlugin Test', () => {
       bucket: 'test-bucket',
       key: 'myproject/auth-default/json',
       secret: '',
+      type: 'onedrive',
     });
 
     nock('https://test-bucket.s3.us-east-1.amazonaws.com')


### PR DESCRIPTION
We pass the type (e.g. `onedrive` or `google`) also to `MemCachePlugin`, and do the check for an empty `Account` only when type is `onedrive` to not interfere with `GoogleTokenCache`.