### PR TITLE
fix: getErrors should be available in all configs

### DIFF
--- a/packages/helix-shared-config/src/BaseConfig.js
+++ b/packages/helix-shared-config/src/BaseConfig.js
@@ -220,4 +220,13 @@ export class BaseConfig {
     }
     return YAML.stringify(this.toJSON());
   }
+
+  /**
+   * Return errors encountered in parsing.
+   *
+   * @returns {String[]} parsing errors
+   */
+  getErrors() {
+    return this._document?.errors ?? [];
+  }
 }

--- a/packages/helix-shared-config/src/IndexConfig.js
+++ b/packages/helix-shared-config/src/IndexConfig.js
@@ -193,13 +193,4 @@ export class IndexConfig extends SchemaDerivedConfig {
     this._version = this._cfg.version;
     return this;
   }
-
-  /**
-   * Return errors encountered in parsing.
-   *
-   * @returns {String[]} parsing errors
-   */
-  getErrors() {
-    return this._document?.errors ?? [];
-  }
 }


### PR DESCRIPTION
related to https://github.com/adobe/helix-shared/pull/1001, same problem might arise in `SitemapConfig`, not just `IndexConfig`
