### PR TITLE
fix: remove unused packages (some deprecated with node 22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11871,6 +11871,7 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -12505,6 +12506,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14850,6 +14852,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -15559,8 +15562,6 @@
         "fs-extra": "11.2.0",
         "ignore": "6.0.2",
         "lru-cache": "11.0.2",
-        "object-hash": "3.0.0",
-        "uri-js": "4.4.1",
         "yaml": "2.6.1"
       },
       "devDependencies": {
@@ -15925,7 +15926,7 @@
       "dependencies": {
         "@adobe/fetch": "^4.1.2",
         "@adobe/helix-shared-process-queue": "^3.0.4",
-        "@aws-sdk/client-s3": "^3.701.0",
+        "@aws-sdk/client-s3": "^3.564.0",
         "@smithy/node-http-handler": "^3.0.0",
         "mime": "^4.0.3"
       },
@@ -15941,7 +15942,7 @@
     },
     "packages/helix-shared-tokencache": {
       "name": "@adobe/helix-shared-tokencache",
-      "version": "1.4.42",
+      "version": "1.4.43",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.10",

--- a/packages/helix-shared-bounce/package.json
+++ b/packages/helix-shared-bounce/package.json
@@ -13,7 +13,6 @@
   "mocha": {
     "reporter": "mocha-multi-reporters",
     "reporter-options": "configFile=.mocha-multi.json",
-    "loader": "esmock",
     "require": [
       "mocha-suppress-logs"
     ]

--- a/packages/helix-shared-config/package.json
+++ b/packages/helix-shared-config/package.json
@@ -46,8 +46,6 @@
     "fs-extra": "11.2.0",
     "ignore": "6.0.2",
     "lru-cache": "11.0.2",
-    "object-hash": "3.0.0",
-    "uri-js": "4.4.1",
     "yaml": "2.6.1"
   },
   "devDependencies": {

--- a/packages/helix-shared-config/src/BaseConfig.js
+++ b/packages/helix-shared-config/src/BaseConfig.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import path from 'path';
 import YAML from 'yaml';
 import { GitUrl } from '@adobe/helix-shared-git';


### PR DESCRIPTION
removed packages:
- `uri-js` (requires `punycode` which is deprecated with node 22)
- `object-hash` (not used at all)
- `fs-extra` (replaced by `fs/promises`)

and removed `esmock` loader directive which is deprecated