### PR TITLE
feat: support rate limiting in processQueue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,6 +2323,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
@@ -7463,6 +7507,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
@@ -7813,6 +7863,13 @@
       "version": "4.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9206,6 +9263,28 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/nocache": {
       "version": "3.0.4",
@@ -13907,6 +13986,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "dev": true,
@@ -14602,6 +14708,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -15957,7 +16072,13 @@
     "packages/helix-shared-process-queue": {
       "name": "@adobe/helix-shared-process-queue",
       "version": "3.0.4",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/helix-shared-async": "2.0.2"
+      },
+      "devDependencies": {
+        "sinon": "19.0.2"
+      }
     },
     "packages/helix-shared-prune": {
       "name": "@adobe/helix-shared-prune",
@@ -16025,7 +16146,7 @@
       "dependencies": {
         "@adobe/fetch": "^4.1.2",
         "@adobe/helix-shared-process-queue": "^3.0.4",
-        "@aws-sdk/client-s3": "^3.741.0",
+        "@aws-sdk/client-s3": "^3.564.0",
         "@smithy/node-http-handler": "^4.0.0",
         "mime": "^4.0.3"
       },
@@ -16045,7 +16166,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.10",
-        "@aws-sdk/client-s3": "^3.741.0"
+        "@aws-sdk/client-s3": "^3.703.0"
       },
       "devDependencies": {
         "nock": "13.5.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16073,6 +16073,9 @@
       "name": "@adobe/helix-shared-process-queue",
       "version": "3.0.4",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/helix-shared-async": "2.0.2"
+      },
       "devDependencies": {
         "sinon": "19.0.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,6 +2323,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
@@ -7463,6 +7507,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
@@ -7813,6 +7863,13 @@
       "version": "4.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9206,6 +9263,28 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/nocache": {
       "version": "3.0.4",
@@ -13907,6 +13986,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "dev": true,
@@ -14602,6 +14708,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -15568,7 +15683,7 @@
     },
     "packages/helix-shared-bounce": {
       "name": "@adobe/helix-shared-bounce",
-      "version": "2.0.25",
+      "version": "2.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.1",
@@ -15957,7 +16072,10 @@
     "packages/helix-shared-process-queue": {
       "name": "@adobe/helix-shared-process-queue",
       "version": "3.0.4",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "sinon": "19.0.2"
+      }
     },
     "packages/helix-shared-prune": {
       "name": "@adobe/helix-shared-prune",
@@ -16025,7 +16143,7 @@
       "dependencies": {
         "@adobe/fetch": "^4.1.2",
         "@adobe/helix-shared-process-queue": "^3.0.4",
-        "@aws-sdk/client-s3": "^3.735.0",
+        "@aws-sdk/client-s3": "^3.564.0",
         "@smithy/node-http-handler": "^4.0.0",
         "mime": "^4.0.3"
       },
@@ -16045,7 +16163,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.10",
-        "@aws-sdk/client-s3": "^3.735.0"
+        "@aws-sdk/client-s3": "^3.703.0"
       },
       "devDependencies": {
         "nock": "13.5.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,6 +2323,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
@@ -7463,6 +7507,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
@@ -7813,6 +7863,13 @@
       "version": "4.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9206,6 +9263,28 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/nocache": {
       "version": "3.0.4",
@@ -13907,6 +13986,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "dev": true,
@@ -14602,6 +14708,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -15957,7 +16072,13 @@
     "packages/helix-shared-process-queue": {
       "name": "@adobe/helix-shared-process-queue",
       "version": "3.0.4",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/helix-shared-async": "2.0.2"
+      },
+      "devDependencies": {
+        "sinon": "19.0.2"
+      }
     },
     "packages/helix-shared-prune": {
       "name": "@adobe/helix-shared-prune",
@@ -16025,7 +16146,7 @@
       "dependencies": {
         "@adobe/fetch": "^4.1.2",
         "@adobe/helix-shared-process-queue": "^3.0.4",
-        "@aws-sdk/client-s3": "^3.740.0",
+        "@aws-sdk/client-s3": "^3.564.0",
         "@smithy/node-http-handler": "^4.0.0",
         "mime": "^4.0.3"
       },
@@ -16045,7 +16166,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.10",
-        "@aws-sdk/client-s3": "^3.740.0"
+        "@aws-sdk/client-s3": "^3.703.0"
       },
       "devDependencies": {
         "nock": "13.5.6"

--- a/packages/helix-shared-process-queue/package.json
+++ b/packages/helix-shared-process-queue/package.json
@@ -30,6 +30,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@adobe/helix-shared-async": "2.0.2"
+  },
   "devDependencies": {
     "sinon": "19.0.2"
   }

--- a/packages/helix-shared-process-queue/package.json
+++ b/packages/helix-shared-process-queue/package.json
@@ -29,5 +29,8 @@
   "homepage": "https://github.com/adobe/helix-shared#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "sinon": "19.0.2"
   }
 }

--- a/packages/helix-shared-process-queue/src/process-queue.d.ts
+++ b/packages/helix-shared-process-queue/src/process-queue.d.ts
@@ -75,6 +75,7 @@ export default function processQueue<
  * @property {number} maxConcurrent Maximum number of items processed concurrently
  * @property {number} limit Maximum number of items processed within the interval
  * @property {number} interval Time window in milliseconds
+ * @property {AbortSignal} abortSignal Optional abort signal
  */
 export declare type RateLimitOptions = {
   maxConcurrent: number;

--- a/packages/helix-shared-process-queue/src/process-queue.d.ts
+++ b/packages/helix-shared-process-queue/src/process-queue.d.ts
@@ -51,9 +51,13 @@ export declare type ProcessQueueHandler<
  * entries during processing. It returns the `results` array which is either populated by the
  * queue handler function directly or with the return values of the handler functions.
  *
+ * Optionally, rate limiting can be applied using a Token Bucket algorithm to throttle the rate at
+ * which tasks are processed.
+ *
  * @param queue A list of entries to be processed
  * @param fn A handler function
- * @param {number} [maxConcurrent = 8] Concurrency level
+ * @param {number} [maxConcurrent=8] Concurrency level
+ * @param {RateLimitOptions} [rateLimitOptions] Optional rate limit options for throttling processing.
  * @returns the results
  */
 export default function processQueue<
@@ -63,7 +67,17 @@ export default function processQueue<
 >(
   queue: TQueue,
   fn: THandler,
-  maxConcurrent?: number
+  maxConcurrent?: number,
+  rateLimitOptions?: RateLimitOptions | null
 ): Promise<TReturn[]>;
 
-
+/**
+ * Rate limiting options for processQueue
+ *
+ * @property {number} limit Maximum number of items processed within the interval
+ * @property {number} interval Time window in milliseconds
+ */
+export declare type RateLimitOptions = {
+  limit: number;
+  interval: number;
+};

--- a/packages/helix-shared-process-queue/src/process-queue.d.ts
+++ b/packages/helix-shared-process-queue/src/process-queue.d.ts
@@ -56,8 +56,7 @@ export declare type ProcessQueueHandler<
  *
  * @param queue A list of entries to be processed
  * @param fn A handler function
- * @param {number} [maxConcurrent=8] Concurrency level
- * @param {RateLimitOptions} [rateLimitOptions] Optional rate limit options for throttling processing.
+ * @param {RateLimitOptions|number} [rateLimitOptions=null] Optional rate limit options for throttling processing.
  * @returns the results
  */
 export default function processQueue<
@@ -67,17 +66,19 @@ export default function processQueue<
 >(
   queue: TQueue,
   fn: THandler,
-  maxConcurrent?: number,
-  rateLimitOptions?: RateLimitOptions | null
+  rateLimitOptions?: RateLimitOptions | number | null
 ): Promise<TReturn[]>;
 
 /**
  * Rate limiting options for processQueue
  *
+ * @property {number} maxConcurrent Maximum number of items processed concurrently
  * @property {number} limit Maximum number of items processed within the interval
  * @property {number} interval Time window in milliseconds
  */
 export declare type RateLimitOptions = {
+  maxConcurrent: number;
   limit: number;
   interval: number;
+  abortSignal?: AbortSignal;
 };

--- a/packages/helix-shared-process-queue/src/process-queue.js
+++ b/packages/helix-shared-process-queue/src/process-queue.js
@@ -137,11 +137,11 @@ export default async function processQueue(
   }
 
   for await (const value of iter) {
+    await waitForToken();
+
     if (abortSignal?.aborted) {
       return results;
     }
-
-    await waitForToken();
 
     while (running.length >= maxConcurrent) {
       // eslint-disable-next-line no-await-in-loop

--- a/packages/helix-shared-process-queue/src/process-queue.js
+++ b/packages/helix-shared-process-queue/src/process-queue.js
@@ -67,7 +67,7 @@ function createRateLimiter(limit, interval) {
 
       // Else, wait before checking again
       // eslint-disable-next-line no-await-in-loop
-      await sleep(interval - (now - lastRefill));
+      await sleep(interval - delta);
     }
   };
 }

--- a/packages/helix-shared-process-queue/src/process-queue.js
+++ b/packages/helix-shared-process-queue/src/process-queue.js
@@ -22,17 +22,79 @@ function* dequeue(queue) {
 }
 
 /**
- * Processes the given queue concurrently. The handler functions can add more items to the queue
- * if needed.
+ * Creates a token bucket rate limiter.
+ *
+ * The token bucket algorithm controls the rate of operations by maintaining a "bucket"
+ * that holds a fixed number of tokens. Each operation that wishes to proceed must first
+ * acquire a token. The bucket is initially filled with `limit` tokens and is refilled
+ * back to that level after every `interval` milliseconds.
+ *
+ * The returned async function, `waitForToken`, implements this logic:
+ * - It checks if enough time has elapsed since the last refill. If so, it refills the bucket
+ * - If a token is available, it decrements the token count and returns immediately
+ * - If no tokens are available, it waits for a short period before trying to refill
+ *
+ * This guarantes that no more than `limit` operations are performed within any
+ * given `interval`, thus enforcing the specified rate limit.
+ *
+ * @param {number} limit Maximum tokens (operations) allowed per interval
+ * @param {number} interval Time period in ms after which the token bucket is refilled
+ * @returns {Function} An async function that waits until a token is available
+ */
+function createRateLimiter(limit, interval) {
+  let tokens = limit;
+  let lastRefill = Date.now();
+
+  return async function waitForToken() {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const now = Date.now();
+
+      // Refill tokens if the interval has passed
+      if (now - lastRefill >= interval) {
+        tokens = limit;
+        lastRefill = now;
+      }
+
+      // If a token is available, consume one and exit
+      if (tokens > 0) {
+        tokens -= 1;
+        return;
+      }
+
+      // Else, wait before checking again
+      // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  };
+}
+
+/**
+ * Processes the given queue concurrently, optionally enforcing rate limits via a Token Bucket.
+ * The handler function may add more items to the queue as needed.
  *
  * @param {Iterable|Array} queue A list of tasks
  * @param {ProcessQueueHandler} fn A handler function `fn(task:any, queue:array, results:array)`
  * @param {number} [maxConcurrent = 8] Concurrency level
+ * @param {RateLimitOptions} [rateLimitOptions=null] Optional rate limiting options
  * @returns {Promise<Array>} the results
  */
-export default async function processQueue(queue, fn, maxConcurrent = 8) {
+export default async function processQueue(queue, fn, maxConcurrent = 8, rateLimitOptions = null) {
   if (typeof queue !== 'object') {
     throw Error('invalid queue argument: iterable expected');
+  }
+
+  // noop by default
+  let waitForToken = async () => {};
+
+  // If rate limiting options are provided, define a token bucket limiter.
+  if (
+    rateLimitOptions
+    && rateLimitOptions.limit != null
+    && rateLimitOptions.interval != null
+  ) {
+    const { limit, interval } = rateLimitOptions;
+    waitForToken = createRateLimiter(limit, interval);
   }
 
   const running = [];
@@ -65,6 +127,8 @@ export default async function processQueue(queue, fn, maxConcurrent = 8) {
   }
 
   for await (const value of iter) {
+    await waitForToken();
+
     while (running.length >= maxConcurrent) {
       // eslint-disable-next-line no-await-in-loop
       await Promise.race(running);

--- a/packages/helix-shared-process-queue/src/process-queue.js
+++ b/packages/helix-shared-process-queue/src/process-queue.js
@@ -102,7 +102,7 @@ export default async function processQueue(
     ? rateLimitOptions
     : { maxConcurrent: rateLimitOptions || 8 };
 
-  const waitForToken = (limit && interval != null)
+  const waitForToken = (limit > 0 && interval > 0)
     ? createRateLimiter(limit, interval, abortSignal)
     : async () => {};
 

--- a/packages/helix-shared-process-queue/src/process-queue.js
+++ b/packages/helix-shared-process-queue/src/process-queue.js
@@ -53,7 +53,8 @@ function createRateLimiter(limit, interval) {
       const now = Date.now();
 
       // Refill tokens if the interval has passed
-      if (now - lastRefill >= interval) {
+      const delta = now - lastRefill;
+      if (delta >= interval) {
         numTokens = limit;
         lastRefill = now;
       }

--- a/packages/helix-shared-process-queue/src/process-queue.js
+++ b/packages/helix-shared-process-queue/src/process-queue.js
@@ -104,7 +104,7 @@ export default async function processQueue(
     : { maxConcurrent: rateLimitOptions || 8 };
 
   const waitForToken = (limit > 0 && interval > 0)
-    ? createRateLimiter(limit, interval, abortSignal)
+    ? createRateLimiter(limit, interval)
     : async () => {};
 
   const running = [];


### PR DESCRIPTION
This PR adds support for rate limiting in `processQueue`. 

The rate limiter uses a token bucket algorithm which maintains a fixed number of tokens (limit) available per interval. Each task consumes a token, and if none are available, it waits until the tokens are replenished after the interval.

This new parameter is optional, if omitted `processQueue` should continue to work as before.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
fixes #1052 
