### PR TITLE
fix: pass abort controller instead to processQueue

### DIFF
--- a/packages/helix-shared-process-queue/src/process-queue.d.ts
+++ b/packages/helix-shared-process-queue/src/process-queue.d.ts
@@ -75,11 +75,11 @@ export default function processQueue<
  * @property {number} maxConcurrent Maximum number of items processed concurrently
  * @property {number} limit Maximum number of items processed within the interval
  * @property {number} interval Time window in milliseconds
- * @property {AbortSignal} abortSignal Optional abort signal
+ * @property {AbortController} abortController Optional abort controller
  */
 export declare type RateLimitOptions = {
   maxConcurrent: number;
   limit: number;
   interval: number;
-  abortSignal?: AbortSignal;
+  abortController?: AbortController;
 };

--- a/packages/helix-shared-process-queue/src/process-queue.js
+++ b/packages/helix-shared-process-queue/src/process-queue.js
@@ -98,7 +98,7 @@ export default async function processQueue(
     limit,
     interval,
     maxConcurrent = 8,
-    abortSignal,
+    abortController,
   } = typeof rateLimitOptions === 'object'
     ? rateLimitOptions
     : { maxConcurrent: rateLimitOptions || 8 };
@@ -139,7 +139,7 @@ export default async function processQueue(
   for await (const value of iter) {
     await waitForToken();
 
-    if (abortSignal?.aborted) {
+    if (abortController?.signal?.aborted) {
       return results;
     }
 

--- a/packages/helix-shared-process-queue/test/process-queue.test.js
+++ b/packages/helix-shared-process-queue/test/process-queue.test.js
@@ -254,7 +254,7 @@ describe('Process Queue', () => {
         maxConcurrent: 2,
         limit: 20,
         interval: 30000,
-        abortSignal: abortController.signal,
+        abortController,
       });
 
       // Increase time enough so that all tasks can complete


### PR DESCRIPTION
As I was adding support for this in bulk preview I realized it would be better to pass the controller instead. The controller has the ability to abort the operation that the signal does not. 

We could work with just the signal in helix-admin but it will be much easier to test if we pass the controller instead.