### PR TITLE
feat: add type to validation error

### DIFF
--- a/packages/helix-shared-config/src/IndexConfig.js
+++ b/packages/helix-shared-config/src/IndexConfig.js
@@ -21,6 +21,7 @@ export class IndexConfig extends SchemaDerivedConfig {
   constructor() {
     super({
       filename: 'helix-query.yaml',
+      type: 'index',
       schemas: {
         '^/$': indexConfigSchema,
         '^/indices/.*$': indexSchema,

--- a/packages/helix-shared-config/src/MountConfig.js
+++ b/packages/helix-shared-config/src/MountConfig.js
@@ -97,6 +97,7 @@ export class MountConfig extends SchemaDerivedConfig {
   constructor() {
     super({
       filename: 'fstab.yaml',
+      type: 'fstab',
       schemas: {
         '^/$': fstabSchema,
         '^/mountpoints/.*$': mountpointSchema,

--- a/packages/helix-shared-config/src/SchemaDerivedConfig.js
+++ b/packages/helix-shared-config/src/SchemaDerivedConfig.js
@@ -27,12 +27,14 @@ export class SchemaDerivedConfig extends BaseConfig {
    */
   constructor({
     filename,
+    type,
     schemas,
     handlers,
   }) {
     super(filename);
 
     this._content = null;
+    this._type = type;
 
     // ensure that sub classes don't accidentally override this properties.
     Object.defineProperties(this, {
@@ -67,7 +69,7 @@ export class SchemaDerivedConfig extends BaseConfig {
     if (res) {
       return res;
     }
-    throw new ValidationError(ajv.errorsText(), ajv.errors);
+    throw new ValidationError(this._type, ajv.errorsText(), ajv.errors);
   }
 
   /**

--- a/packages/helix-shared-config/src/SitemapConfig.js
+++ b/packages/helix-shared-config/src/SitemapConfig.js
@@ -21,6 +21,7 @@ export class SitemapConfig extends SchemaDerivedConfig {
   constructor() {
     super({
       filename: 'helix-sitemap.yaml',
+      type: 'sitemap',
       schemas: {
         '^/$': sitemapConfigSchema,
         '^/sitemaps/.*$': sitemapSchema,

--- a/packages/helix-shared-config/src/ValidationError.js
+++ b/packages/helix-shared-config/src/ValidationError.js
@@ -13,13 +13,14 @@
 
 export class ValidationError extends Error {
   constructor(
+    type,
     msg,
     errors = [],
     mapError = ValidationError.mapError,
     prettyname = ValidationError.prettyname,
   ) {
     const detail = errors.map((e) => mapError(e, prettyname)).join('\n');
-    super(`Invalid configuration:
+    super(`Invalid ${type} configuration:
 ${detail}
 
 ${msg}`);

--- a/packages/helix-shared-config/test/mountpoints.test.js
+++ b/packages/helix-shared-config/test/mountpoints.test.js
@@ -100,7 +100,7 @@ const tests = [
     title: 'fails with a broken config',
     config: 'broken.yaml',
     result: null,
-    error: 'Error: Invalid configuration:\nFSTab (Mount Points) has unknown property \'mounts\'\n\ndata must NOT have additional properties',
+    error: 'Error: Invalid fstab configuration:\nFSTab (Mount Points) has unknown property \'mounts\'\n\ndata must NOT have additional properties',
   },
   {
     title: 'loads a theblog example',

--- a/packages/helix-shared-config/test/sitemapconfigs.test.js
+++ b/packages/helix-shared-config/test/sitemapconfigs.test.js
@@ -45,31 +45,31 @@ const tests = [
   {
     title: 'loads an example without hreflang',
     config: 'broken.yaml',
-    error: `Error: Invalid configuration:
+    error: `Error: Invalid sitemap configuration:
 Sitemap Language must have required property 'hreflang'`,
   },
   {
     title: 'loads an example without destination',
     config: 'broken2.yaml',
-    error: `Error: Invalid configuration:
+    error: `Error: Invalid sitemap configuration:
 Sitemap Language must have required property 'destination'`,
   },
   {
     title: 'loads an example with invalid hreflang',
     config: 'broken3.yaml',
-    error: `Error: Invalid configuration:
+    error: `Error: Invalid sitemap configuration:
 HREF Language must match pattern`,
   },
   {
     title: 'loads an example with invalid hreflangs array',
     config: 'broken4.yaml',
-    error: `Error: Invalid configuration:
+    error: `Error: Invalid sitemap configuration:
 HREF Language must match pattern`,
   },
   {
     title: 'loads an example with a language defining lastmod',
     config: 'broken5.yaml',
-    error: `Error: Invalid configuration:
+    error: `Error: Invalid sitemap configuration:
 Sitemap Language has unknown property 'lastmod'`,
   },
 ];


### PR DESCRIPTION
This will make the error more readable, see the following response seen in the logs:
```
Error: Invalid configuration:undefined must be object: type(null, {"type":"object"})data/mountpoints must be object
```
It should be clear from the beginning, what configuration _type_ is invalid.