### PR TITLE
fix: steady rate limiting with releasable tokens

### DIFF
--- a/packages/helix-shared-process-queue/src/process-queue.d.ts
+++ b/packages/helix-shared-process-queue/src/process-queue.d.ts
@@ -30,6 +30,13 @@ export declare type QueueEntryType<TQueue extends Queue> = TQueue extends Array<
   ? T : never;
 
 /**
+ * A token object that can be released.
+ */
+export declare type Token = {
+  release(): void;
+};
+
+/**
  * A (asynchronous) handler function that is invoked for every queue entry.
  * Values added to the `results` array will be returned by `processQueue` function.
  * The handler can modify the `queue` if needed.
@@ -38,13 +45,14 @@ export declare type QueueEntryType<TQueue extends Queue> = TQueue extends Array<
  * @param entry The queue entry.
  * @param queue the queue.
  * @param results the process queue results
+ * @param token an object that can be used to release a token.
  * @return result or undefined.
  */
 export declare type ProcessQueueHandler<
   TQueue extends Queue,
   TEntry extends QueueEntry = QueueEntryType<TQueue>,
   TReturn = any
-> = (entry: TEntry, queue: TQueue, results: TReturn[]) => PromiseLike<TReturn>;
+> = (entry: TEntry, queue: TQueue, results: TReturn[], token: Token) => PromiseLike<TReturn>;
 
 /**
  * Processes the given queue concurrently. If the `queue` is an array it will remove the


### PR DESCRIPTION
This PR replaces the token bucket algorithm with a sliding window rate limiting approach. The previous token bucket allowed bursts by refilling a fixed number of tokens at set intervals, which could lead to uneven execution timings after idle periods. With the sliding window, the limiter continuously tracks recent task start times and enforces an even, steady pace by ensuring that no more than a specified number of tasks start within any given interval. This change results in a smoother and more predictable distribution of task start times that better aligns with external API limits, while still respecting the configured concurrency settings.

This PR also adds support for token "releasing". This allows the tasks to release the provided token if no operation was performed. For example, if the resource is not modified, the task should not consume a token and contribute to the rate limit.

fixes #1070 