### PR TITLE
SSA-292 - Helix-shared-storage/HelixStorage - Bucket population 

### DIFF
--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -616,6 +616,11 @@ export class HelixStorage {
         CLOUDFLARE_R2_ACCESS_KEY_ID: r2AccessKeyId,
         CLOUDFLARE_R2_SECRET_ACCESS_KEY: r2SecretAccessKey,
         HELIX_STORAGE_DISABLE_R2: disableR2,
+        AWS_REGION: region = process.env.AWS_REGION || 'us-east-1',
+        CONTENT_BUS_BUCKET: contentBusBucket = process.env.CONTENT_BUS_BUCKET || 'helix-content-bus',
+        CODE_BUS_BUCKET: codeBusBucket = process.env.CODE_BUS_BUCKET || 'helix-code-bus',
+        MEDIA_BUS_BUCKET: mediaBusBucket = process.env.MEDIA_BUS_BUCKET || 'helix-media-bus',
+        CONFIG_BUS_BUCKET: configBusBucket = process.env.CONFIG_BUS_BUCKET || 'helix-config-bus',
       } = context.env;
 
       context.attributes.storage = new HelixStorage({
@@ -627,6 +632,11 @@ export class HelixStorage {
         disableR2: String(disableR2) === 'true',
         keepAlive: String(keepAlive) === 'true',
         log: context.log,
+        region,
+        contentBusBucket,
+        codeBusBucket,
+        mediaBusBucket,
+        configBusBucket,
       });
     }
     return context.attributes.storage;
@@ -650,15 +660,26 @@ export class HelixStorage {
    * @param {strong} [opts.r2AccessKeyId]
    * @param {strong} [opts.r2SecretAccessKey]
    * @param {object} [opts.log] logger
+   * @param {string} [opts.contentBusBucket]
+   * @param {string} [opts.codeBusBucket]
+   * @param {string} [opts.mediaBusBucket]
+   * @param {string} [opts.configBusBucket]
    */
   constructor(opts = {}) {
     const {
-      region = 'us-east-1', accessKeyId, secretAccessKey,
+      region, accessKeyId, secretAccessKey,
       connectionTimeout, socketTimeout,
       r2AccountId, r2AccessKeyId, r2SecretAccessKey, disableR2,
       log = console,
       keepAlive = true,
+      contentBusBucket, codeBusBucket, mediaBusBucket, configBusBucket,
     } = opts;
+
+    this.region = region;
+    this._contentBusBucket = contentBusBucket;
+    this._codeBusBucket = codeBusBucket;
+    this._mediaBusBucket = mediaBusBucket;
+    this._configBusBucket = configBusBucket;
 
     if (region && accessKeyId && secretAccessKey) {
       log.debug('Creating S3Client with credentials');
@@ -743,28 +764,28 @@ export class HelixStorage {
    * @returns {Bucket}
    */
   contentBus(disableR2 = false) {
-    return this.bucket('helix-content-bus', disableR2);
+    return this.bucket(this._contentBusBucket || 'helix-content-bus', disableR2);
   }
 
   /**
    * @returns {Bucket}
    */
   codeBus(disableR2 = false) {
-    return this.bucket('helix-code-bus', disableR2);
+    return this.bucket(this._codeBusBucket || 'helix-code-bus', disableR2);
   }
 
   /**
    * @returns {Bucket}
    */
   mediaBus() {
-    return this.bucket('helix-media-bus');
+    return this.bucket(this._mediaBusBucket || 'helix-media-bus');
   }
 
   /**
    * @returns {Bucket}
    */
   configBus() {
-    return this.bucket('helix-config-bus');
+    return this.bucket(this._configBusBucket || 'helix-config-bus');
   }
 
   /**

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -139,6 +139,56 @@ describe('Storage test', () => {
     assert.strictEqual(storage.contentBus().bucket, 'helix-content-bus');
   });
 
+  it('Empty attributes override default buckets', () => {
+    process.env.CONTENT_BUS_BUCKET = 'content-test-bus';
+    process.env.CODE_BUS_BUCKET = 'code-test-bus';
+    process.env.MEDIA_BUS_BUCKET = 'media-test-bus';
+    process.env.CONFIG_BUS_BUCKET = 'config-test-bus';
+    delete process.env.AWS_REGION;
+
+    const ctx = {
+      env: {
+        AWS_ACCESS_KEY_ID: 'fake',
+        AWS_SECRET_ACCESS_KEY: 'fake',
+        CLOUDFLARE_ACCOUNT_ID: 'fake',
+        CLOUDFLARE_R2_ACCESS_KEY_ID: 'fake',
+        CLOUDFLARE_R2_SECRET_ACCESS_KEY: 'fake',
+      },
+      attributes: {},
+    };
+
+    const stor = HelixStorage.fromContext(ctx);
+    assert.strictEqual(stor.region, 'us-east-1');
+    assert.strictEqual(stor.contentBus().bucket, 'content-test-bus');
+    assert.strictEqual(stor.codeBus().bucket, 'code-test-bus');
+    assert.strictEqual(stor.mediaBus().bucket, 'media-test-bus');
+    assert.strictEqual(stor.configBus().bucket, 'config-test-bus');
+  });
+
+  it('No env variables populated bucket population', () => {
+    delete process.env.CONTENT_BUS_BUCKET;
+    delete process.env.CODE_BUS_BUCKET;
+    delete process.env.MEDIA_BUS_BUCKET;
+    delete process.env.CONFIG_BUS_BUCKET;
+
+    const ctx = {
+      env: {
+        AWS_ACCESS_KEY_ID: 'fake',
+        AWS_SECRET_ACCESS_KEY: 'fake',
+        CLOUDFLARE_ACCOUNT_ID: 'fake',
+        CLOUDFLARE_R2_ACCESS_KEY_ID: 'fake',
+        CLOUDFLARE_R2_SECRET_ACCESS_KEY: 'fake',
+      },
+      attributes: {},
+    };
+
+    const stor = HelixStorage.fromContext(ctx);
+    assert.strictEqual(stor.contentBus().bucket, 'helix-content-bus');
+    assert.strictEqual(stor.codeBus().bucket, 'helix-code-bus');
+    assert.strictEqual(stor.mediaBus().bucket, 'helix-media-bus');
+    assert.strictEqual(stor.configBus().bucket, 'helix-config-bus');
+  });
+
   it('can get the code-bus', () => {
     assert.strictEqual(storage.codeBus().bucket, 'helix-code-bus');
   });


### PR DESCRIPTION
Enabling variablized bucket support for helix-shared-storage/HelixStorage function.  Tests validated on helix-admin and on this module:

helix-shared-storage >>>BEFORE:
------------------------------------------
object uploaded to: helix-code-bus/foo
    ✔ can put object
  43 passing (256ms)
 
helix-shared-storage >>> AFTER:
------------------------------------------
object uploaded to: helix-code-bus/foo
    ✔ can put object
  45 passing (263ms)
  
  
 helix admin >>> BEFORE:
------------------------------------------
  1673 passing (33s)
  3 pending
=============================== Coverage summary ===============================
Statements   : 100% ( 27437/27437 )
Branches     : 100% ( 5486/5486 )
Functions    : 100% ( 747/747 )
Lines        : 100% ( 27437/27437 )
================================================================================


helix admin >>> AFTER:
------------------------------------------
  1673 passing (33s)
  3 pending
=============================== Coverage summary ===============================
Statements   : 100% ( 27437/27437 )
Branches     : 100% ( 5486/5486 )
Functions    : 100% ( 747/747 )
Lines        : 100% ( 27437/27437 )
================================================================================
 