### PR TITLE
feat: add 14-day minimum release age for external dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -79,7 +79,8 @@
         "after 2pm on Monday"
       ],
       "matchPackagePatterns": ["^.+"],
-      "excludePackagePatterns": ["^@adobe/"]
+      "excludePackagePatterns": ["^@adobe/"],
+      "minimumReleaseAge": "14 days"
     },
     {
       "groupName": "external major",
@@ -87,7 +88,8 @@
       "automerge": false,
       "matchPackagePatterns": ["^.+"],
       "excludePackagePatterns": ["^@adobe/"],
-      "schedule": ["after 2pm on Monday"]
+      "schedule": ["after 2pm on Monday"],
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchDatasources": ["orb"],


### PR DESCRIPTION
## Summary
- Added `minimumReleaseAge: "14 days"` policy to external dependency update rules in Renovate configuration
- Applies to both minor/patch updates and major updates for non-Adobe packages
- Provides a buffer period for potential security issues to be discovered before automatic updates

## Context
This change adds an additional security layer in response to recent supply chain attacks on npm packages. By waiting 14 days before considering updates, we allow time for the community to identify and report compromised packages.

Related discussion: https://cq-dev.slack.com/archives/C01UB5Y1YQ7/p1757493562576669
Reference article: https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised

## Test plan
- [ ] Verify JSON syntax is valid
- [ ] Confirm Renovate accepts the configuration
- [ ] Monitor that external dependency updates are delayed by 14 days after release

🤖 Generated with [Claude Code](https://claude.ai/code)