### PR TITLE
Fix mislabeled README titles

### DIFF
--- a/packages/helix-shared-ims/README.md
+++ b/packages/helix-shared-ims/README.md
@@ -1,1 +1,1 @@
-# Helix Shared - wrap
+# Helix Shared - ims

--- a/packages/helix-shared-prune/README.md
+++ b/packages/helix-shared-prune/README.md
@@ -1,1 +1,1 @@
-# Helix Shared - string
+# Helix Shared - prune


### PR DESCRIPTION
## Background
Some README files in the `packages` directory have incorrect titles, leading to confusion about their purpose.

## Changes
- Updated `packages/helix-shared-ims/README.md` title from "# Helix Shared - wrap" to "# Helix Shared - ims".
- Updated `packages/helix-shared-prune/README.md` title from "# Helix Shared - string" to "# Helix Shared - prune".

## Related Issues
N/A

Thanks for contributing!
