### PR TITLE
feat: option to include subfolder prefixes in bucket.list()

### DIFF
--- a/packages/helix-shared-storage/src/storage.d.ts
+++ b/packages/helix-shared-storage/src/storage.d.ts
@@ -47,6 +47,10 @@ export interface ListOptions {
    */
   shallow: boolean;
   /**
+   * whether to include subfolder prefixes
+   */
+  subPrefixes: boolean;
+  /**
    * max number of items to return
    */
   maxItems: number;

--- a/packages/helix-shared-storage/src/storage.d.ts
+++ b/packages/helix-shared-storage/src/storage.d.ts
@@ -47,9 +47,9 @@ export interface ListOptions {
    */
   shallow: boolean;
   /**
-   * whether to include subfolder prefixes
+   * whether to include prefixes (for subfolders)
    */
-  subPrefixes: boolean;
+  prefixes: boolean;
   /**
    * max number of items to return
    */

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -508,7 +508,7 @@ class Bucket {
    */
   async list(prefix, opts = false) {
     const {
-      shallow = false, maxItems = Number.POSITIVE_INFINITY,
+      shallow = false, maxItems = Number.POSITIVE_INFINITY, subPrefixes = false,
     } = typeof opts === 'boolean' ? { shallow: opts } : opts;
 
     let ContinuationToken;
@@ -526,6 +526,16 @@ class Bucket {
       // eslint-disable-next-line no-await-in-loop
       const result = await this.client.send(new ListObjectsV2Command(input));
       ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
+
+      if (subPrefixes) {
+        (result.CommonPrefixes || []).forEach(({ Prefix }) => {
+          objects.push({
+            key: Prefix,
+            path: `${Prefix.substring(prefix.length)}`,
+          });
+        });
+      }
+
       (result.Contents || []).forEach((content) => {
         const key = content.Key;
         objects.push({

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -508,7 +508,7 @@ class Bucket {
    */
   async list(prefix, opts = false) {
     const {
-      shallow = false, maxItems = Number.POSITIVE_INFINITY, subPrefixes = false,
+      shallow = false, maxItems = Number.POSITIVE_INFINITY, prefixes = false,
     } = typeof opts === 'boolean' ? { shallow: opts } : opts;
 
     let ContinuationToken;
@@ -527,7 +527,7 @@ class Bucket {
       const result = await this.client.send(new ListObjectsV2Command(input));
       ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
 
-      if (subPrefixes) {
+      if (prefixes) {
         (result.CommonPrefixes || []).forEach(({ Prefix }) => {
           objects.push({
             key: Prefix,

--- a/packages/helix-shared-storage/test/fixtures/list-subfolder-prefixes.json
+++ b/packages/helix-shared-storage/test/fixtures/list-subfolder-prefixes.json
@@ -1,0 +1,21 @@
+{
+  "ListBucketResult": {
+    "Name": "helix-code-bus",
+    "Prefix": "",
+    "NextContinuationToken": "next",
+    "KeyCount": 1,
+    "MaxKeys": 1,
+    "Delimiter": "/",
+    "IsTruncated": false,
+    "Contents": [{
+      "Key": "/owner/repo/ref/myfolder/somefile.html",
+      "LastModified": "2021-06-06T04:05:06.000Z",
+      "Size": "999999"
+    }],
+    "CommonPrefixes": [{
+      "Prefix": "/owner/repo/ref/myfolder/sub1/"
+    }, {
+      "Prefix": "/owner/repo/ref/myfolder/sub2/"
+    }]
+  }
+}

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1123,7 +1123,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const folders = await bus.list('/owner/repo/ref/', { subPrefixes: true });
+    const folders = await bus.list('/owner/repo/ref/', { prefixes: true });
 
     assert.deepStrictEqual(folders, [
       {
@@ -1157,7 +1157,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const folders = await bus.list('/owner/repo/ref/myfolder/', { subPrefixes: true });
+    const folders = await bus.list('/owner/repo/ref/myfolder/', { prefixes: true });
 
     assert.deepStrictEqual(folders, [
       {

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1123,7 +1123,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const folders = await bus.list('/owner/repo/ref/');
+    const folders = await bus.list('/owner/repo/ref/', { subPrefixes: true });
 
     assert.deepStrictEqual(folders, [
       {
@@ -1146,6 +1146,54 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/src/scripts.js',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: 'src/scripts.js',
+      },
+    ]);
+  });
+
+  it('can list to include subfolder prefixes', async () => {
+    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/?list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
+      .reply(200, new xml2js.Builder().buildObject(listReply));
+
+    const bus = storage.codeBus();
+    const folders = await bus.list('/owner/repo/ref/myfolder/', { subPrefixes: true });
+
+    assert.deepStrictEqual(folders, [
+      {
+        key: '/owner/repo/ref/myfolder/sub1/',
+        path: 'sub1/',
+      },
+      {
+        key: '/owner/repo/ref/myfolder/sub2/',
+        path: 'sub2/',
+      },
+      {
+        contentLength: 999999,
+        contentType: 'text/html',
+        key: '/owner/repo/ref/myfolder/somefile.html',
+        lastModified: new Date('2021-06-06T04:05:06.000Z'),
+        path: 'somefile.html',
+      },
+    ]);
+  });
+
+  it('can list to not include subfolder prefixes', async () => {
+    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/?list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
+      .reply(200, new xml2js.Builder().buildObject(listReply));
+
+    const bus = storage.codeBus();
+    const folders = await bus.list('/owner/repo/ref/myfolder/');
+
+    assert.deepStrictEqual(folders, [
+      {
+        contentLength: 999999,
+        contentType: 'text/html',
+        key: '/owner/repo/ref/myfolder/somefile.html',
+        lastModified: new Date('2021-06-06T04:05:06.000Z'),
+        path: 'somefile.html',
       },
     ]);
   });


### PR DESCRIPTION
To include subfolder prefixes in the result, use:

    bucket.list(path, { subPrefixes: true })
