### PR TITLE
feat: bucket.put() stores uncompressed length as metadata

### DIFF
--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -335,7 +335,7 @@ class Bucket {
     if (compress) {
       input.ContentEncoding = 'gzip';
       input.Body = await gzip(body);
-      input.Metadata['uncompressed-length'] = body.length.toString();
+      input.Metadata['uncompressed-length'] = String(body.length);
     }
     // write to s3 and r2 (mirror) in parallel
     const measures = Array.from({ length: this._clients.length });

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -335,6 +335,7 @@ class Bucket {
     if (compress) {
       input.ContentEncoding = 'gzip';
       input.Body = await gzip(body);
+      input.Metadata['uncompressed-length'] = body.length.toString();
     }
     // write to s3 and r2 (mirror) in parallel
     const measures = Array.from({ length: this._clients.length });

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -34,6 +34,7 @@ const CLOUDFLARE_R2_SECRET_ACCESS_KEY = 'fake';
 const TEST_HEADERS = [
   'content-type',
   'content-encoding',
+  'x-amz-meta-uncompressed-length',
   'x-amz-meta-myid',
 ];
 
@@ -317,6 +318,7 @@ describe('Storage test', () => {
         headers: {
           'content-encoding': 'gzip',
           'content-type': 'text/plain',
+          'x-amz-meta-uncompressed-length': '13',
           'x-amz-meta-myid': '1234',
         },
       },
@@ -1303,6 +1305,7 @@ describe('Disabled R2 Storage test', () => {
         headers: {
           'content-encoding': 'gzip',
           'content-type': 'text/plain',
+          'x-amz-meta-uncompressed-length': '13',
           'x-amz-meta-myid': '1234',
         },
       },


### PR DESCRIPTION
If bucket.put() needs to compress the body, the original uncompressed content length is stored as the `x-amz-meta-uncompressed-length` metadata attribute on the object.
