### PR TITLE
Revert "feat: bucket.put() stores uncompressed length as metadata"

### DIFF
--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -335,7 +335,6 @@ class Bucket {
     if (compress) {
       input.ContentEncoding = 'gzip';
       input.Body = await gzip(body);
-      input.Metadata['uncompressed-length'] = String(body.length);
     }
     // write to s3 and r2 (mirror) in parallel
     const measures = Array.from({ length: this._clients.length });

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -34,7 +34,6 @@ const CLOUDFLARE_R2_SECRET_ACCESS_KEY = 'fake';
 const TEST_HEADERS = [
   'content-type',
   'content-encoding',
-  'x-amz-meta-uncompressed-length',
   'x-amz-meta-myid',
 ];
 
@@ -318,7 +317,6 @@ describe('Storage test', () => {
         headers: {
           'content-encoding': 'gzip',
           'content-type': 'text/plain',
-          'x-amz-meta-uncompressed-length': '13',
           'x-amz-meta-myid': '1234',
         },
       },
@@ -1305,7 +1303,6 @@ describe('Disabled R2 Storage test', () => {
         headers: {
           'content-encoding': 'gzip',
           'content-type': 'text/plain',
-          'x-amz-meta-uncompressed-length': '13',
           'x-amz-meta-myid': '1234',
         },
       },


### PR DESCRIPTION
Reverts adobe/helix-shared#1172

New discussion suggests to move this elsewhere.