### PR TITLE
feat: add toSISize function with comprehensive tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1560,7 +1560,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -1705,7 +1704,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3312,7 +3310,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5499,7 +5496,6 @@
       "integrity": "sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8229,7 +8225,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12044,7 +12039,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13671,7 +13665,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -15338,7 +15331,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/helix-shared-string/src/string.js
+++ b/packages/helix-shared-string/src/string.js
@@ -157,3 +157,21 @@ export function editDistance(s0, s1) {
   }
   return resultMatrix[l0][l1];
 }
+
+/**
+ * Converts a number of bytes to a human-readable size string in SI units.
+ * @param {number} bytes The number of bytes to convert.
+ * @param {number} [precision=2] The number of decimal places to include in the result.
+ * @returns {string} A human-readable size string in SI units.
+ */
+export function toSISize(bytes, precision = 2) {
+  if (bytes === 0) {
+    return '0B';
+  }
+  const mags = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+  const LOG_1024 = Math.log(1024);
+
+  const magnitude = Math.floor(Math.log(Math.abs(bytes)) / LOG_1024);
+  const result = bytes / (1024 ** magnitude);
+  return `${result.toFixed(magnitude === 0 ? 0 : precision)}${mags[magnitude]}`;
+}

--- a/packages/helix-shared-string/test/string.test.js
+++ b/packages/helix-shared-string/test/string.test.js
@@ -14,7 +14,7 @@
 
 import assert from 'assert';
 import {
-  multiline, editDistance, sanitizeName, sanitizePath, splitByExtension,
+  multiline, editDistance, sanitizeName, sanitizePath, splitByExtension, toSISize,
 } from '../src/string.js';
 
 describe('String tests', () => {
@@ -175,5 +175,73 @@ describe('sanitizePath Tests', () => {
 
   it('sanitizePath normalizes unicode', () => {
     assert.strictEqual(sanitizePath('Föhren Smürd'), 'fohren-smurd');
+  });
+});
+
+describe('toSISize Tests', () => {
+  it('toSISize handles zero bytes', () => {
+    assert.strictEqual(toSISize(0), '0B');
+  });
+
+  it('toSISize handles bytes without decimals', () => {
+    assert.strictEqual(toSISize(1), '1B');
+    assert.strictEqual(toSISize(512), '512B');
+    assert.strictEqual(toSISize(1023), '1023B');
+  });
+
+  it('toSISize handles kilobytes with default precision', () => {
+    assert.strictEqual(toSISize(1024), '1.00KB');
+    assert.strictEqual(toSISize(1536), '1.50KB');
+    assert.strictEqual(toSISize(2048), '2.00KB');
+    assert.strictEqual(toSISize(10240), '10.00KB');
+  });
+
+  it('toSISize handles megabytes', () => {
+    assert.strictEqual(toSISize(1024 * 1024), '1.00MB');
+    assert.strictEqual(toSISize(1.5 * 1024 * 1024), '1.50MB');
+    assert.strictEqual(toSISize(100 * 1024 * 1024), '100.00MB');
+  });
+
+  it('toSISize handles gigabytes', () => {
+    assert.strictEqual(toSISize(1024 * 1024 * 1024), '1.00GB');
+    assert.strictEqual(toSISize(5.25 * 1024 * 1024 * 1024), '5.25GB');
+  });
+
+  it('toSISize handles terabytes', () => {
+    assert.strictEqual(toSISize(1024 * 1024 * 1024 * 1024), '1.00TB');
+    assert.strictEqual(toSISize(2.5 * 1024 * 1024 * 1024 * 1024), '2.50TB');
+  });
+
+  it('toSISize handles petabytes', () => {
+    assert.strictEqual(toSISize(1024 * 1024 * 1024 * 1024 * 1024), '1.00PB');
+  });
+
+  it('toSISize handles exabytes', () => {
+    assert.strictEqual(toSISize(1024 * 1024 * 1024 * 1024 * 1024 * 1024), '1.00EB');
+  });
+
+  it('toSISize handles custom precision', () => {
+    assert.strictEqual(toSISize(1536, 0), '2KB');
+    assert.strictEqual(toSISize(1536, 1), '1.5KB');
+    assert.strictEqual(toSISize(1536, 3), '1.500KB');
+    assert.strictEqual(toSISize(1.23456 * 1024 * 1024, 4), '1.2346MB');
+  });
+
+  it('toSISize handles negative numbers', () => {
+    assert.strictEqual(toSISize(-1024), '-1.00KB');
+    assert.strictEqual(toSISize(-1536), '-1.50KB');
+    assert.strictEqual(toSISize(-1024 * 1024), '-1.00MB');
+  });
+
+  it('toSISize handles fractional bytes', () => {
+    assert.strictEqual(toSISize(123.45), '123B');
+    assert.strictEqual(toSISize(999.99), '1000B');
+  });
+
+  it('toSISize handles edge cases near magnitude boundaries', () => {
+    assert.strictEqual(toSISize(1023.9), '1024B');
+    assert.strictEqual(toSISize(1024.1), '1.00KB');
+    assert.strictEqual(toSISize(1048575), '1024.00KB');
+    assert.strictEqual(toSISize(1048576), '1.00MB');
   });
 });


### PR DESCRIPTION
## Description

This PR adds a new `toSISize()` function to convert bytes to human-readable size strings in SI units.

## Changes

- **New Function**: `toSISize(bytes, precision = 2)`
  - Converts bytes to human-readable format (B, KB, MB, GB, TB, PB, EB)
  - Supports configurable precision (default: 2 decimal places)
  - Handles edge cases: zero bytes, negative numbers, fractional bytes
  - No decimals for bytes (magnitude 0)

- **Comprehensive Test Suite**: 12 new tests covering:
  - Zero bytes
  - Various byte values without decimals
  - All magnitude conversions (KB through EB)
  - Custom precision parameter
  - Negative numbers
  - Fractional bytes
  - Edge cases near magnitude boundaries

## Testing

All 43 tests passing with 100% code coverage maintained.

```bash
npm test
# 43 passing (11ms)
# Coverage: 100% statements, 100% branches, 100% functions, 100% lines
```