### PR TITLE
fix(git): handle URL path prefixes in GitUrl parsing

### DIFF
--- a/packages/helix-shared-git/src/GitUrl.js
+++ b/packages/helix-shared-git/src/GitUrl.js
@@ -86,6 +86,7 @@ export class GitUrl {
       if (parts === null) {
         throw Error(`Invalid URL: Not a valid git url: ${url}`);
       }
+      // noinspection JSConsecutiveCommasInArrayLiteral
       [, this._owner, this._repo, this._path] = parts;
       this._ref = this._url.hash.substring(1);
       // add defaults if missing

--- a/packages/helix-shared-git/src/GitUrl.js
+++ b/packages/helix-shared-git/src/GitUrl.js
@@ -18,7 +18,7 @@ const RAW_TYPE = 'raw';
 const API_TYPE = 'api';
 const DEFAULT_BRANCH = 'master';
 const MATCH_IP = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/;
-const MATCH_GIT_URL = /\/([^/]+)\/([^/]+)\/?$/;
+const MATCH_GIT_URL = /\/([^/]+)\/([^/]+?)(?:\.git(\/.*)?|\/?)$/;
 /**
  * Represents a GIT url.
  */
@@ -82,15 +82,11 @@ export class GitUrl {
         this._url = new URL(url);
       }
 
-      const { pathname } = this._url;
-      const gitIdx = pathname.search(/\.git(\/|$)/);
-      const repoPath = gitIdx > -1 ? pathname.substring(0, gitIdx) : pathname;
-      const parts = MATCH_GIT_URL.exec(repoPath);
+      const parts = MATCH_GIT_URL.exec(this._url.pathname);
       if (parts === null) {
         throw Error(`Invalid URL: Not a valid git url: ${url}`);
       }
-      [, this._owner, this._repo] = parts;
-      this._path = gitIdx > -1 ? (pathname.substring(gitIdx + 4) || undefined) : undefined;
+      [, this._owner, this._repo, this._path] = parts;
       this._ref = this._url.hash.substring(1);
       // add defaults if missing
       if (!this._path && 'path' in defaults) {

--- a/packages/helix-shared-git/src/GitUrl.js
+++ b/packages/helix-shared-git/src/GitUrl.js
@@ -18,7 +18,7 @@ const RAW_TYPE = 'raw';
 const API_TYPE = 'api';
 const DEFAULT_BRANCH = 'master';
 const MATCH_IP = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/;
-const MATCH_GIT_URL = /\.git(\/|$)/;
+const MATCH_GIT_URL = /\/([^/]+)\/([^/]+)\/?$/;
 /**
  * Represents a GIT url.
  */
@@ -83,16 +83,14 @@ export class GitUrl {
       }
 
       const { pathname } = this._url;
-      // Use .git (followed by / or end-of-string) as the boundary between owner/repo and path
-      const gitMatch = MATCH_GIT_URL.exec(pathname);
-      const ownerRepoPart = gitMatch ? pathname.substring(0, gitMatch.index) : pathname;
-      const segments = ownerRepoPart.split('/').filter(Boolean);
-      if (segments.length < 2) {
+      const gitIdx = pathname.search(/\.git(\/|$)/);
+      const repoPath = gitIdx > -1 ? pathname.substring(0, gitIdx) : pathname;
+      const parts = MATCH_GIT_URL.exec(repoPath);
+      if (parts === null) {
         throw Error(`Invalid URL: Not a valid git url: ${url}`);
       }
-      this._owner = segments[segments.length - 2];
-      this._repo = segments[segments.length - 1];
-      this._path = gitMatch ? (pathname.substring(gitMatch.index + 4) || undefined) : undefined;
+      [, this._owner, this._repo] = parts;
+      this._path = gitIdx > -1 ? (pathname.substring(gitIdx + 4) || undefined) : undefined;
       this._ref = this._url.hash.substring(1);
       // add defaults if missing
       if (!this._path && 'path' in defaults) {

--- a/packages/helix-shared-git/src/GitUrl.js
+++ b/packages/helix-shared-git/src/GitUrl.js
@@ -18,7 +18,7 @@ const RAW_TYPE = 'raw';
 const API_TYPE = 'api';
 const DEFAULT_BRANCH = 'master';
 const MATCH_IP = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/;
-const MATCH_GIT_URL = /^\/([^/]+)\/([^/]+)(\/.*)?$/;
+const MATCH_GIT_URL = /\.git(\/|$)/;
 /**
  * Represents a GIT url.
  */
@@ -82,12 +82,19 @@ export class GitUrl {
         this._url = new URL(url);
       }
 
-      const parts = MATCH_GIT_URL.exec(this._url.pathname);
-      if (parts === null) {
+      const { pathname } = this._url;
+      // If .git is present, use it as the boundary between owner/repo and path.
+      // Match .git only when followed by / or end-of-string to avoid false positives
+      // in names like "repo.github.io.git".
+      const gitMatch = MATCH_GIT_URL.exec(pathname);
+      const ownerRepoPart = gitMatch ? pathname.substring(0, gitMatch.index) : pathname;
+      const segments = ownerRepoPart.split('/').filter(Boolean);
+      if (segments.length < 2) {
         throw Error(`Invalid URL: Not a valid git url: ${url}`);
       }
-      // noinspection JSConsecutiveCommasInArrayLiteral
-      [, this._owner, this._repo, this._path] = parts;
+      this._owner = segments[segments.length - 2];
+      this._repo = segments[segments.length - 1];
+      this._path = gitMatch ? (pathname.substring(gitMatch.index + 4) || undefined) : undefined;
       this._ref = this._url.hash.substring(1);
       // add defaults if missing
       if (!this._path && 'path' in defaults) {

--- a/packages/helix-shared-git/src/GitUrl.js
+++ b/packages/helix-shared-git/src/GitUrl.js
@@ -83,9 +83,7 @@ export class GitUrl {
       }
 
       const { pathname } = this._url;
-      // If .git is present, use it as the boundary between owner/repo and path.
-      // Match .git only when followed by / or end-of-string to avoid false positives
-      // in names like "repo.github.io.git".
+      // Use .git (followed by / or end-of-string) as the boundary between owner/repo and path
       const gitMatch = MATCH_GIT_URL.exec(pathname);
       const ownerRepoPart = gitMatch ? pathname.substring(0, gitMatch.index) : pathname;
       const segments = ownerRepoPart.split('/').filter(Boolean);

--- a/packages/helix-shared-git/test/giturl.test.js
+++ b/packages/helix-shared-git/test/giturl.test.js
@@ -391,6 +391,41 @@ describe('GitUrl from string tests', () => {
     assert.equal(url.isLocal, true);
   });
 
+  it('URL with path prefix (local proxy, no .git suffix)', () => {
+    const url = new GitUrl('http://local_proxy@127.0.0.1:45823/git/owner/my-repo');
+    assert.equal(url.owner, 'owner');
+    assert.equal(url.repo, 'my-repo');
+    assert.equal(url.hostname, '127.0.0.1');
+    assert.equal(url.port, '45823');
+    assert.equal(url.path, '');
+    assert.equal(url.ref, '');
+  });
+
+  it('URL with path prefix and .git suffix', () => {
+    const url = new GitUrl('http://proxy.example.com:8080/git/company/repository.git');
+    assert.equal(url.owner, 'company');
+    assert.equal(url.repo, 'repository');
+    assert.equal(url.path, '');
+    assert.equal(url.ref, '');
+  });
+
+  it('URL with deep path prefix, .git suffix, path, and ref', () => {
+    const url = new GitUrl('http://proxy.example.com/scm/git/company/repository.git/docs/main#products/v2');
+    assert.equal(url.owner, 'company');
+    assert.equal(url.repo, 'repository');
+    assert.equal(url.path, '/docs/main');
+    assert.equal(url.ref, 'products/v2');
+  });
+
+  it('Fails for .git URL with only one path segment', () => {
+    try {
+      const url = new GitUrl('https://github.com/repo.git');
+      assert.ok(!url, 'should fail');
+    } catch (e) {
+      assert.equal(e.message, 'Invalid URL: Not a valid git url: https://github.com/repo.git');
+    }
+  });
+
   it('Fails for non scp-url arguments', () => {
     try {
       const url = new GitUrl('git@github.com/no/git');


### PR DESCRIPTION
## Summary

- `GitUrl` assumed pathnames always start with `/<owner>/<repo>`, but proxies and enterprise git servers can add path prefixes (e.g. `/git/owner/repo`, `/scm/PROJECT/repo.git`)
- Uses `.git` as an anchor to locate the repo boundary and takes the last two segments before it as owner/repo
- Falls back to last two path segments when no `.git` suffix is present

Fixes #1207

## Test plan

- [x] Added test for local proxy URL with path prefix and no `.git` suffix (the exact scenario that triggered this)
- [x] Added test for path prefix with `.git` suffix
- [x] Added test for deep path prefix with `.git` suffix, path, and ref
- [x] Added test for error case: `.git` URL with only one path segment
- [x] All 44 existing + new tests pass
- [x] 100% code coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>