### PR TITLE
feat(storage)!: harmonize Bucket.list/browse, add browse + isFolder, d.ts/JSDoc cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository layout
+
+This is an npm workspaces **monorepo** of shared libraries for Project Helix. Each subdirectory of `packages/` is an independently-versioned, independently-published package under `@adobe/helix-shared-*` (e.g. `@adobe/helix-shared-config`, `@adobe/helix-shared-utils`, `@adobe/helix-shared-storage`). Packages are ESM-only (`"type": "module"`) and may depend on each other via the `^` range.
+
+Don't add a top-level `@adobe/helix-shared` package — it was retired. Consumers import the specific sub-package they need.
+
+## Common commands
+
+Run from the repo root unless noted:
+
+- `npm install` — install all workspace deps
+- `npm test` — run tests across every workspace (`npm test --workspaces`)
+- `npm run lint` — lint every workspace
+- `npm run docs` — regenerate `docs/` (JSON-schema markdown + JSDoc API)
+
+Per-package work (run inside `packages/<name>/`, or pass `--workspace=@adobe/helix-shared-<name>` from root):
+
+- `npm test` — `c8 mocha` with coverage; tests live in `test/*.test.js` and use `test/setup-env.js` as a mocha `--require` hook
+- `npm run lint` — `eslint .`
+- Single test file: `npx mocha test/SomeThing.test.js`
+- Single test by name: `npx mocha test/SomeThing.test.js -g "partial title"`
+- Auto-fix lint: `npx eslint . --fix`
+
+## Releases
+
+Each package releases independently via **semantic-release** with `semantic-release-monorepo` (see `.releaserc.cjs`). Versions are derived from Conventional Commits on `main`:
+
+- `fix:` → patch, `feat:` → minor, `BREAKING CHANGE:` footer → major
+- `chore(release): ...` commits with `[skip ci]` are made by the release bot — do not author these manually
+- Husky + `lint-staged` run `eslint` on staged `*.js` at commit time
+
+## Packages
+
+Most packages are middleware "wrappers" composed via `@adobe/helix-shared-wrap`'s `.with()` chain on a main handler. A few (`config`, `git`, `storage`, `string`, `utils`, `async`, `process-queue`, `prune`, `tokencache`, `indexer`) are plain libraries.
+
+- **helix-shared-async** — Tiny async primitives (`sleep(ms)`, `nextTick()`). Used to yield to the event loop or pause within async flows.
+- **helix-shared-body-data** — Wrap middleware that parses form/JSON request bodies (POST/PUT) and exposes them on `context.data` for Helix Universal serverless functions.
+- **helix-shared-bounce** — Wrap middleware that races a "fast" responder against the slow main handler and returns whichever finishes first; the slow side keeps running via fetch so it isn't aborted. Supports a `debounce` predicate to skip bouncing per request.
+- **helix-shared-config** — Loads, validates, and exposes Helix YAML configs (`helix-config.yaml`, `helix-fstab.yaml`, `helix-query.yaml`, `helix-markup.yaml`) via JSON Schema. The largest package; see "Architecture notes" below.
+- **helix-shared-git** — `GitUrl` class that parses, normalizes, and re-emits Git URLs with `protocol/hostname/owner/repo/ref/path`. Used everywhere Helix needs to identify a repo+ref.
+- **helix-shared-ims** — Wrap middleware that authenticates requests against Adobe IMS (stage/prod) and exposes `context.ims.profile`. Configurable scope, `forceAuth` for required-auth endpoints.
+- **helix-shared-indexer** — HTML-to-record indexer driven by `helix-query.yaml` `indices` config. Resolves CSS selectors, applies value/values expressions (`textContent`, `attribute`, `match`, etc.) to produce queryable records.
+- **helix-shared-process-queue** — Bounded-concurrency async task runner. Takes a list of tasks plus a worker fn; returns aggregated results, with optional access to in-progress results inside the worker.
+- **helix-shared-prune** — `pruneEmptyValues(obj)` recursively strips falsy values and empty arrays from an object in place. Returns `null` when everything is removed; used to keep configs/payloads tidy.
+- **helix-shared-secrets** — Wrap middleware that loads secrets (currently AWS Secrets Manager) named `<package>/<function>` into `context` and `process.env` before the handler runs. Supports a custom `nameFunction` for non-default paths.
+- **helix-shared-server-timing** — Wrap middleware that injects a `timer` onto `context`; `timer.update(label)` records milestones and the response automatically gets a `Server-Timing` header.
+- **helix-shared-storage** — `HelixStorage` client over AWS S3 and Cloudflare R2 with `bucket(name).get/put/...`. Most consumers create it from the Helix function `context` rather than direct credentials.
+- **helix-shared-string** — String helpers: `multiline` (template-string dedent), `splitByExtension`, `sanitizeName`, `sanitizePath`, `editDistance`. Plain functions, no dependencies.
+- **helix-shared-tokencache** — Layered (memory + persistent) cache plugins for OAuth tokens, with `getCachePlugin` auto-discovering storage at `helix-content-bus/<id>/.helix-auth`, `helix-code-bus/<owner>/.helix-auth`, or a default fallback. Used for OneDrive and similar long-lived auth.
+- **helix-shared-utils** — Backend-response status mapping (`propagateStatusCode`, `logLevelForStatusCode` — e.g. 500→502, 429→503), header sanitization, and other small gateway utilities. Imported by most other packages.
+- **helix-shared-wrap** — The composition primitive: `wrap(main).with(a).with(b)` produces a handler where the **last** wrapper added runs **first**. All other wrap-based middleware in this repo plugs into this.
+
+## Architecture notes
+
+- **`helix-shared-config`** is the largest package and the historical heart of the repo. It loads, validates, and exposes Helix YAML configs (`helix-config.yaml`, `helix-fstab.yaml`, `helix-query.yaml`, `helix-markup.yaml`). It uses a `SchemaDerivedConfig` base that drives object construction from JSON Schemas in `src/schemas/`; validation errors flow through `ValidationError.js`. Handlers like `MountPointHandler`, `SitemapHandler`, `NamedMapHandler` translate validated schema fragments into runtime objects. `fetchconfig/` retrieves configs from remote sources (GitHub, etc.) with caching. The `docs:schema` script regenerates `docs/*.md` from these schemas — re-run it after schema changes.
+- **Builder/fluent API pattern**: classes like `HelixConfig` use `.withSource(yaml)` / `.withJSON(obj)` / `.withDirectory(path)` followed by `await .init()`. Preserve this shape in additions.
+- **HTTP**: tests pin `HELIX_FETCH_FORCE_HTTP1=true` (set in `test/setup-env.js`) for determinism with `nock` and `@pollyjs`. Don't remove that without a plan.
+- **Cross-package imports** must use the published name (`@adobe/helix-shared-utils`), never a relative `../helix-shared-utils/...` path — the workspace symlink makes both work locally but only the former works after publish.
+
+## ESLint config
+
+Each package extends the root `eslint.config.js`, which composes `@adobe/eslint-config-helix`'s `recommended`, `source`, and `test` configs. Test files use the `test` config (looser globals, etc.) — keep test code under `test/`.

--- a/packages/helix-shared-storage/src/storage.d.ts
+++ b/packages/helix-shared-storage/src/storage.d.ts
@@ -32,8 +32,18 @@ import { Response } from "@adobe/fetch";
 export interface ObjectInfo {
   /** absolute object key (including the listing prefix) */
   key: string;
-  /** the path to the object, relative to the listing prefix */
+  /**
+   * the path to the object. For {@link Bucket.list} this is relative to the
+   * listed prefix; for {@link Bucket.browse} it is relative to the browse
+   * `prefix` (the root) and always starts with `/`.
+   */
   path: string;
+  /**
+   * the basename of the object — the last path segment, with any trailing
+   * `/` stripped. E.g. `2024` for a common prefix `/blog/2024/`,
+   * `post.md` for an object key `/blog/post.md`.
+   */
+  name: string;
   /** last-modified timestamp as returned by S3; absent for common prefixes */
   lastModified?: Date;
   /** object size in bytes; absent for common prefixes */
@@ -323,13 +333,24 @@ export declare interface Bucket {
   /**
    * Single-page, always-shallow listing intended for paginated UI browsing.
    *
+   * `prefix` is the fixed root of the subtree being browsed (constant during
+   * navigation); `path` is the subdirectory within that root currently being
+   * listed. The actual S3 prefix sent is `prefix + path`. Each returned
+   * `ObjectInfo.path` is relative to `prefix` (and starts with `/`), so the
+   * caller can pass an entry's `path` straight back as the next call's `path`
+   * argument to drill in.
+   *
    * Unlike {@link Bucket.list}, `browse` does not auto-page through the result:
    * it issues one `ListObjectsV2` call, returns the entries it received, and
    * exposes the `NextContinuationToken` (if any) so the caller can request the
    * next page when the user navigates forward. `maxItems` controls the page
    * size only.
+   *
+   * @param prefix root of the subtree being browsed
+   * @param path subdirectory within `prefix` to list. Normalized to start
+   *  with `/`. Defaults to `'/'`.
    */
-  browse(prefix: string, opts?: BrowseOptions): Promise<BrowseResult>;
+  browse(prefix: string, path?: string, opts?: BrowseOptions): Promise<BrowseResult>;
 
   /**
    * Copies the tree below `src` to `dst`. Concurrency is fixed at 64; per-object errors are

--- a/packages/helix-shared-storage/src/storage.d.ts
+++ b/packages/helix-shared-storage/src/storage.d.ts
@@ -24,31 +24,35 @@ import {
 import { Response } from "@adobe/fetch";
 
 /**
- * Information about a single object (or common prefix) returned by {@link Bucket.list}.
+ * Information about a single entry — file or folder — returned by
+ * {@link Bucket.list} or {@link Bucket.browse}.
  *
- * When the entry represents a common prefix (folder) — i.e. when {@link ListOptions.includePrefixes}
- * is `true` — only `key` and `path` are populated.
+ * When the entry represents a common prefix (folder), `isFolder` is `true`
+ * and `lastModified`/`contentLength`/`contentType` are absent.
  */
 export interface ObjectInfo {
-  /** absolute object key (including the listing prefix) */
+  /** absolute object key. For folders, S3's `CommonPrefix` value (ends with `/`). */
   key: string;
   /**
-   * the path to the object. For {@link Bucket.list} this is relative to the
-   * listed prefix; for {@link Bucket.browse} it is relative to the browse
-   * `prefix` (the root) and always starts with `/`.
+   * Path relative to the listing's `prefix` argument. Always starts with
+   * `/` and never ends with `/` — the {@link ObjectInfo.isFolder} flag
+   * carries the file/folder distinction. The same form the caller would
+   * pass back as the `path` argument to drill into a folder.
    */
   path: string;
   /**
-   * the basename of the object — the last path segment, with any trailing
-   * `/` stripped. E.g. `2024` for a common prefix `/blog/2024/`,
-   * `post.md` for an object key `/blog/post.md`.
+   * Basename of the entry — the last path segment, with any trailing `/`
+   * stripped. E.g. `2024` for a folder `/blog/2024/`, `post.md` for an
+   * object key `/blog/post.md`.
    */
   name: string;
-  /** last-modified timestamp as returned by S3; absent for common prefixes */
+  /** `true` for common prefixes (folders); `false` for object keys (files). */
+  isFolder: boolean;
+  /** last-modified timestamp as returned by S3. Files only. */
   lastModified?: Date;
-  /** object size in bytes; absent for common prefixes */
+  /** object size in bytes. Files only. */
   contentLength?: number;
-  /** content type guessed from the key extension; absent for common prefixes */
+  /** content type guessed from the key extension. Files only. */
   contentType?: string | null;
 }
 
@@ -90,30 +94,27 @@ export interface BrowseOptions {
    * at 1000 by S3; defaults to the S3 default when omitted.
    */
   maxItems?: number;
-  /**
-   * Whether to include common prefixes (subfolders) as entries in the result.
-   * Defaults to `true`, since browsing typically wants folder-style navigation.
-   */
-  includePrefixes?: boolean;
-}
-
-export interface BrowseResult {
-  /** the page of objects (and, when {@link BrowseOptions.includePrefixes}, common prefixes) */
-  objects: ObjectInfo[];
-  /**
-   * Continuation token to pass back to {@link Bucket.browse} to fetch the next
-   * page. `undefined` when the listing has been exhausted.
-   */
-  continuationToken?: string;
 }
 
 export interface ListOptions {
   /** whether to list shallow, i.e. not recursive (uses `/` as delimiter). Default `false`. */
   shallow?: boolean;
-  /** whether to include common prefixes (subfolders) as entries. Default `false`. */
-  includePrefixes?: boolean;
-  /** maximum number of items to return. Default unlimited. */
+  /** maximum number of items to return across all pages. Default unlimited. */
   maxItems?: number;
+}
+
+/**
+ * Common return shape for {@link Bucket.list} and {@link Bucket.browse}.
+ *
+ * `continuationToken` is `undefined` for {@link Bucket.list} (which always
+ * auto-paginates) and for an exhausted {@link Bucket.browse} call; it is set
+ * when {@link Bucket.browse} hits a truncated S3 response.
+ */
+export interface ListResult {
+  /** the page of entries (files and, for shallow listings, folders) */
+  objects: ObjectInfo[];
+  /** continuation token to pass back to {@link Bucket.browse} for the next page */
+  continuationToken?: string;
 }
 
 /**
@@ -317,40 +318,37 @@ export declare interface Bucket {
   ): Promise<BulkDeleteResult>;
 
   /**
-   * List objects below `prefix`.
+   * Auto-paginated listing of entries below `prefix + path`.
    *
-   * @param prefix the key prefix to list under
-   * @param opts list options. As a backward-compatibility shortcut, passing `true` is
-   *  equivalent to `{ shallow: true }`.
+   * `prefix` is the fixed root of the subtree; `path` is the subdirectory
+   * within it (always interpreted as a directory: normalized to start *and*
+   * end with `/`). When `shallow: true`, common prefixes (folders directly
+   * below the listed dir) are returned alongside files; callers filter by
+   * `isFolder` if they want only one kind. Each returned `ObjectInfo.path`
+   * is relative to `prefix`.
+   *
+   * @param prefix root of the subtree to list under
+   * @param path subdirectory within `prefix`. Defaults to `'/'`.
    */
-  list(prefix: string, opts?: boolean | ListOptions): Promise<ObjectInfo[]>;
-
-  /**
-   * List the common prefixes (subfolders) directly below `prefix`. Always shallow.
-   */
-  listFolders(prefix: string): Promise<string[]>;
+  list(prefix: string, path?: string, opts?: ListOptions): Promise<ListResult>;
 
   /**
    * Single-page, always-shallow listing intended for paginated UI browsing.
    *
-   * `prefix` is the fixed root of the subtree being browsed (constant during
-   * navigation); `path` is the subdirectory within that root currently being
-   * listed. The actual S3 prefix sent is `prefix + path`. Each returned
-   * `ObjectInfo.path` is relative to `prefix` (and starts with `/`), so the
-   * caller can pass an entry's `path` straight back as the next call's `path`
-   * argument to drill in.
+   * Same `prefix` / `path` conventions as {@link Bucket.list}. Unlike `list`,
+   * `browse` does not auto-page: it issues one `ListObjectsV2` call, returns
+   * the entries it received, and exposes the `NextContinuationToken` (if
+   * any) so the caller can request the next page on demand. `maxItems`
+   * controls the page size only.
    *
-   * Unlike {@link Bucket.list}, `browse` does not auto-page through the result:
-   * it issues one `ListObjectsV2` call, returns the entries it received, and
-   * exposes the `NextContinuationToken` (if any) so the caller can request the
-   * next page when the user navigates forward. `maxItems` controls the page
-   * size only.
+   * Each returned `ObjectInfo.path` is in the same form as the `path`
+   * argument, so the caller can pass an entry's `path` straight back to
+   * drill in.
    *
    * @param prefix root of the subtree being browsed
-   * @param path subdirectory within `prefix` to list. Normalized to start
-   *  with `/`. Defaults to `'/'`.
+   * @param path subdirectory within `prefix` to list. Defaults to `'/'`.
    */
-  browse(prefix: string, path?: string, opts?: BrowseOptions): Promise<BrowseResult>;
+  browse(prefix: string, path?: string, opts?: BrowseOptions): Promise<ListResult>;
 
   /**
    * Copies the tree below `src` to `dst`. Concurrency is fixed at 64; per-object errors are

--- a/packages/helix-shared-storage/src/storage.d.ts
+++ b/packages/helix-shared-storage/src/storage.d.ts
@@ -333,6 +333,18 @@ export declare interface Bucket {
   list(prefix: string, path?: string, opts?: ListOptions): Promise<ListResult>;
 
   /**
+   * Convenience wrapper around {@link Bucket.list} that returns only the
+   * folder paths directly below `prefix + path`. Equivalent to
+   * `(await list(prefix, path, { shallow: true })).objects.filter(o => o.isFolder).map(o => o.path)`.
+   *
+   * @param prefix root of the subtree
+   * @param path subdirectory within `prefix`. Defaults to `'/'`.
+   * @returns folder paths, each relative to `prefix`, starting with `/`,
+   *  never ending with `/`
+   */
+  listFolders(prefix: string, path?: string): Promise<string[]>;
+
+  /**
    * Single-page, always-shallow listing intended for paginated UI browsing.
    *
    * Same `prefix` / `path` conventions as {@link Bucket.list}. Unlike `list`,

--- a/packages/helix-shared-storage/src/storage.d.ts
+++ b/packages/helix-shared-storage/src/storage.d.ts
@@ -10,193 +10,367 @@
  * governing permissions and limitations under the License.
  */
 
-import { S3Client } from "@aws-sdk/client-s3";
+import {
+  CopyObjectCommandInput,
+  CopyObjectCommandOutput,
+  CopyObjectResult,
+  DeleteObjectCommandOutput,
+  DeleteObjectsCommandOutput,
+  HeadObjectCommandInput,
+  HeadObjectCommandOutput,
+  PutObjectCommandOutput,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { Response } from "@adobe/fetch";
 
-
+/**
+ * Information about a single object (or common prefix) returned by {@link Bucket.list}.
+ *
+ * When the entry represents a common prefix (folder) — i.e. when {@link ListOptions.includePrefixes}
+ * is `true` — only `key` and `path` are populated.
+ */
 export interface ObjectInfo {
+  /** absolute object key (including the listing prefix) */
   key: string;
-  /** the path to the object, w/o the prefix */
+  /** the path to the object, relative to the listing prefix */
   path: string;
-  lastModified: string;
-  contentLength: number;
-  contentType: string;
+  /** last-modified timestamp as returned by S3; absent for common prefixes */
+  lastModified?: Date;
+  /** object size in bytes; absent for common prefixes */
+  contentLength?: number;
+  /** content type guessed from the key extension; absent for common prefixes */
+  contentType?: string | null;
 }
 
 /**
- * @returns {boolean} {@code true} if the object is accepted
+ * Filter callback used by {@link Bucket.copyDeep}.
+ *
+ * @returns `true` if the object should be included in the operation
  */
 export type ObjectFilter = (info: ObjectInfo) => boolean;
 
 export interface CopyOptions {
   /**
-   * metadata to rename, { [from:string] => to:string }
-   * Removes existing `from` metadata property from the copied object.
-   * Use `addMetadata` to include the `from` property if needed.
+   * Metadata keys to rename, in the form `{ [from]: to }`.
+   * Removes the existing `from` metadata property from the copied object.
+   * Use {@link CopyOptions.addMetadata} to keep the `from` property as well.
    */
   renameMetadata?: Record<string, string>;
   /**
    * Metadata to merge with existing metadata.
-   * Properties are applied after `renameMetadata`.
+   * Properties are applied after {@link CopyOptions.renameMetadata}.
    */
-  addMetadata?: Record<string, unknown>;
+  addMetadata?: Record<string, string>;
   /**
-   * Options to pass to the CopyObjectCommand.
+   * Additional fields to merge into the underlying `CopyObjectCommand` input
+   * (e.g. `CacheControl`, `ContentType`, `Tagging`, ...).
    */
-  copyOpts?: Record<string, string>;
+  copyOpts?: Partial<CopyObjectCommandInput>;
 }
 
 export interface ListOptions {
-  /**
-   * whether to list shallow i.e. not recursive
-   */
-  shallow: boolean;
-  /**
-   * whether to include prefixes (for subfolders)
-   */
-  includePrefixes: boolean;
-  /**
-   * max number of items to return
-   */
-  maxItems: number;
-}
-
-export declare interface Bucket {
-  get client(): S3Client;
-
-  get bucket(): string;
-
-  get log(): Console;
-
-  get(key: string, meta?: object): Promise<Buffer | null>;
-
-  head(path: string, headOpts?: object): Promise<object | null>;
-
-  /**
-   * Return an object's metadata.
-   *
-   * @param {string} key object key
-   * @returns object metadata or null
-   * @throws an error if the object could not be loaded due to an unexpected error.
-   */
-  metadata(key: string): Promise<object | null>;
-
-  /**
-   * Store an object contents, along with headers.
-   *
-   * @param {string} key object key
-   * @param {Response} res response to store
-   * @returns result obtained from S3
-   */
-  store(key: string, res: Response): Promise<object>;
-
-  /**
-   * Store an object contents, along with metadata.
-   *
-   * @param {string} path object key
-   * @param {Buffer|string} body data to store
-   * @param {string} [contentType] content type. defaults to 'application/octet-stream'
-   * @param {object} [meta] metadata to store with the object. defaults to '{}'
-   * @param {boolean} [compress = true]
-   * @returns result obtained from S3
-   */
-  put(path: string, body: Buffer, contentType?: string, meta?: object, compress?: boolean): Promise<object>;
-
-  /**
-   * Updates the metadata
-   * @param {string} path
-   * @param {object} meta
-   * @param {object} opts
-   * @returns {Promise<*>}
-   */
-  putMeta(path: string, meta: object, opts?: object): Promise<object>;
-
-  /**
-   * Copy an object in the same bucket.
-   *
-   * @param {string} src source key
-   * @param {string} dst destination key
-   * @param {CopyOptions} [opts]
-   * @returns {Promise<import('@aws-sdk/client-s3').CopyObjectResult>}
-   */
-  copy(src: string, dst: string, opts?: CopyOptions): Promise<object>;
-
-  /**
-   * Remove object(s)
-   *
-   * @param {string|string[]} path source key(s)
-   * @returns result obtained from S3
-   */
-  remove(path: string): Promise<object>;
-
-  /**
-   * Returns a list of object below the given prefix
-   * @param {string} prefix
-   * @param {boolean|ListOptions} [opts]
-   * @returns {Promise<ObjectInfo[]>}
-   */
-  list(prefix: string, opts: boolean|ListOptions): Promise<ObjectInfo[]>;
-
-  listFolders(prefix: string): Promise<string[]>;
-
-  /**
-   * Copies the tree below src to dst.
-   * @param {string} src Source prefix
-   * @param {string} dst Destination prefix
-   * @param {ObjectFilter} filter Filter function
-   * @param {CopyOptions} [opts]
-   * @returns {Promise<*[]>}
-   */
-  copyDeep(src: string, dst: string, filter?: ObjectFilter, opts?: CopyOptions): Promise<object[]>;
-
-  rmdir(src: string): Promise<void>;
+  /** whether to list shallow, i.e. not recursive (uses `/` as delimiter). Default `false`. */
+  shallow?: boolean;
+  /** whether to include common prefixes (subfolders) as entries. Default `false`. */
+  includePrefixes?: boolean;
+  /** maximum number of items to return. Default unlimited. */
+  maxItems?: number;
 }
 
 /**
- * The Helix Storage provides a factory for simplified bucket operations to S3 and R2
+ * Aggregated result returned by {@link Bucket.remove} when invoked with an array of keys.
+ */
+export interface BulkDeleteResult {
+  Deleted: NonNullable<DeleteObjectsCommandOutput["Deleted"]>;
+  Errors: NonNullable<DeleteObjectsCommandOutput["Errors"]>;
+}
+
+/**
+ * Options for {@link HelixStorage}.
+ */
+export interface HelixStorageOptions {
+  /** AWS region. Defaults to `us-east-1`. */
+  region?: string;
+  /** AWS access key. If omitted, the SDK default credential chain is used. */
+  accessKeyId?: string;
+  /** AWS secret access key. */
+  secretAccessKey?: string;
+  /** Cloudflare account id used to derive the R2 endpoint. */
+  r2AccountId?: string;
+  /** R2 access key id. */
+  r2AccessKeyId?: string;
+  /** R2 secret access key. */
+  r2SecretAccessKey?: string;
+  /** When `true`, disables the R2 mirror entirely. */
+  disableR2?: boolean;
+  /**
+   * JSON string mapping bus keys (`config`, `code`, `content`, `media`, `source`)
+   * to their actual bucket names. If omitted, defaults to `helix-<key>-bus`.
+   */
+  bucketNames?: string;
+  /** Whether to enable HTTP keep-alive on the underlying agent. Default `true`. */
+  keepAlive?: boolean;
+  /** Connection timeout in milliseconds passed to the HTTP handler. */
+  connectionTimeout?: number;
+  /** Socket timeout in milliseconds passed to the HTTP handler. */
+  socketTimeout?: number;
+  /** Logger; defaults to `console`. */
+  log?: Console;
+  /** Max retry attempts for the underlying S3 clients. */
+  maxAttempts?: number;
+}
+
+/**
+ * Helix function context shape used by {@link HelixStorage.fromContext}. The storage instance
+ * is cached on `context.attributes.storage`; configuration is read from `context.env`.
+ */
+export interface HelixStorageContext {
+  env: Record<string, string | undefined>;
+  log: Console;
+  attributes: {
+    storage?: HelixStorage;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Mapping from bus key to bucket name as parsed by {@link parseBucketNames}.
+ */
+export interface BucketMap {
+  config: string;
+  code: string;
+  content: string;
+  media: string;
+  source: string;
+  [key: string]: string;
+}
+
+/**
+ * Parses the `HELIX_BUCKET_NAMES` env var (a JSON object) into a {@link BucketMap}.
+ * When `bucketNames` is falsy, returns the default `helix-<key>-bus` mapping.
+ */
+export declare function parseBucketNames(bucketNames?: string): BucketMap;
+
+/**
+ * Resolves the metadata that should be written by a copy operation, given the
+ * source object's response headers and the rename/add directives from {@link CopyOptions}.
+ */
+export declare function resolveMetadataForCopy(
+  s3Headers?: Record<string, unknown>,
+  renameMeta?: Record<string, string>,
+  addMeta?: Record<string, string>,
+): Record<string, string>;
+
+/**
+ * Wraps a single S3 (and optional R2 mirror) bucket. All write operations are issued in
+ * parallel against both clients; reads use the primary S3 client only.
+ */
+export declare interface Bucket {
+  /** the primary S3 client used for reads and the first leg of writes */
+  get client(): S3Client;
+
+  /** the bucket name */
+  get bucket(): string;
+
+  /** the logger */
+  get log(): Console;
+
+  /**
+   * Fetch an object's body. Transparently un-gzips objects whose `ContentEncoding` is `gzip`.
+   *
+   * @param key object key
+   * @param meta optional output object that receives the object's metadata and selected
+   *  system headers (`CacheControl`, `ContentType`, `ContentEncoding`, `ETag`, `Expires`,
+   *  `LastModified`)
+   * @returns object contents as a Buffer, or `null` when the key does not exist
+   * @throws when the object cannot be loaded for a non-404 reason
+   */
+  get(key: string, meta?: Record<string, unknown>): Promise<Buffer | null>;
+
+  /**
+   * Issue a HEAD on the object and return the raw S3 response.
+   *
+   * @param path object key
+   * @param headOpts extra fields merged into the `HeadObjectCommand` input
+   * @returns the HEAD response, or `null` when the key does not exist
+   */
+  head(path: string, headOpts?: Partial<HeadObjectCommandInput>): Promise<HeadObjectCommandOutput | null>;
+
+  /**
+   * Return an object's user metadata.
+   *
+   * @param key object key
+   * @returns the object's metadata map, or `undefined` when the key does not exist
+   * @throws when the object cannot be loaded for a non-404 reason
+   */
+  metadata(key: string): Promise<Record<string, string> | undefined>;
+
+  /**
+   * Store an object body and headers from a fetch `Response`. The body is gzipped (or passed
+   * through if the response is already `content-encoding: gzip`); response headers are mapped
+   * to the corresponding S3 system headers / user metadata. Mirrored to R2 when enabled.
+   *
+   * Returns no value; failures throw.
+   */
+  store(key: string, res: Response): Promise<void>;
+
+  /**
+   * Store an object's contents along with metadata. Mirrored to R2 when enabled.
+   *
+   * @param path object key
+   * @param body data to store
+   * @param contentType content type. Defaults to `application/octet-stream`.
+   * @param meta metadata to store with the object. Defaults to `{}`.
+   * @param compress whether to gzip the body and set `ContentEncoding: gzip`. Defaults to `true`.
+   * @returns the result from the primary S3 PutObject call
+   */
+  put(
+    path: string,
+    body: Buffer | string,
+    contentType?: string,
+    meta?: Record<string, string>,
+    compress?: boolean,
+  ): Promise<PutObjectCommandOutput>;
+
+  /**
+   * Replace an object's user metadata via a self-copy with `MetadataDirective: REPLACE`.
+   *
+   * @param path object key
+   * @param meta new metadata (fully replaces existing metadata)
+   * @param opts extra fields merged into the `CopyObjectCommand` input
+   */
+  putMeta(
+    path: string,
+    meta: Record<string, string>,
+    opts?: Partial<CopyObjectCommandInput>,
+  ): Promise<CopyObjectCommandOutput>;
+
+  /**
+   * Copy an object within the same bucket. When `addMetadata` or `renameMetadata` are
+   * provided, the source's HEAD is consulted so that selected system headers are preserved
+   * and metadata can be rewritten with `MetadataDirective: REPLACE`.
+   *
+   * @throws an error with `status: 404` when the source key does not exist
+   */
+  copy(src: string, dst: string, opts?: CopyOptions): Promise<CopyObjectResult | undefined>;
+
+  /**
+   * Remove a single object.
+   *
+   * @returns the raw `DeleteObject` response
+   * @throws an error with `status` set to the HTTP status code on failure
+   */
+  remove(path: string): Promise<DeleteObjectCommandOutput>;
+
+  /**
+   * Remove multiple objects. Slices the input into chunks of up to 1000 keys (the S3 limit)
+   * and issues them in parallel (concurrency 2).
+   *
+   * @param paths source keys
+   * @param sourceInfo informational message used in log output
+   * @param stopOnError when `true`, throws on the first chunk that fails; otherwise errors
+   *  are accumulated into the returned `Errors` array
+   */
+  remove(
+    paths: string[],
+    sourceInfo?: string,
+    stopOnError?: boolean,
+  ): Promise<BulkDeleteResult>;
+
+  /**
+   * List objects below `prefix`.
+   *
+   * @param prefix the key prefix to list under
+   * @param opts list options. As a backward-compatibility shortcut, passing `true` is
+   *  equivalent to `{ shallow: true }`.
+   */
+  list(prefix: string, opts?: boolean | ListOptions): Promise<ObjectInfo[]>;
+
+  /**
+   * List the common prefixes (subfolders) directly below `prefix`. Always shallow.
+   */
+  listFolders(prefix: string): Promise<string[]>;
+
+  /**
+   * Copies the tree below `src` to `dst`. Concurrency is fixed at 64; per-object errors are
+   * logged but do not abort the operation.
+   *
+   * @param filter optional filter; only objects for which it returns truthy are copied
+   * @returns the list of tasks that were copied successfully
+   */
+  copyDeep(
+    src: string,
+    dst: string,
+    filter?: ObjectFilter,
+    opts?: CopyOptions,
+  ): Promise<Array<{
+    src: string;
+    dst: string;
+    path: string;
+    contentLength?: number;
+    contentType?: string | null;
+  }>>;
+
+  /**
+   * Recursively delete every object below `src`.
+   */
+  rmdir(src: string): Promise<BulkDeleteResult>;
+}
+
+/**
+ * The Helix Storage provides a factory for simplified bucket operations to S3 and R2.
+ *
+ * Writes are mirrored: every mutating call (`put`, `store`, `copy`, `putMeta`, `remove`)
+ * is dispatched in parallel to the primary S3 client and to the R2 client when enabled.
  */
 export declare class HelixStorage {
-  static fromContext(context: AdminContext): HelixStorage;
+  /**
+   * Mapping from lowercase HTTP header name to the corresponding `*Command` input property.
+   * Used internally to translate response headers into S3 system fields.
+   */
+  static AWS_S3_SYSTEM_HEADERS: Record<string, string>;
 
+  /**
+   * Get (and lazily construct + cache) a {@link HelixStorage} instance for a Helix
+   * function `context`. The instance is stored on `context.attributes.storage`.
+   */
+  static fromContext(context: HelixStorageContext): HelixStorage;
+
+  constructor(opts?: HelixStorageOptions);
+
+  /** the underlying primary S3 client */
   s3(): S3Client;
 
   /**
-   * creates a bucket instance that allows to perform storage related operations.
-   * @param bucketId
-   * @param disableR2 whether to disable writing to R2
-   * @returns {Bucket}
+   * Create a {@link Bucket} for the given bucket id.
+   *
+   * @param bucketId bucket name
+   * @param disableR2 when `true`, this bucket will not mirror writes to R2
+   *  (even if R2 is otherwise configured)
    */
-  bucket(bucketId: string, disableR2: boolean = false): Bucket;;
+  bucket(bucketId: string, disableR2?: boolean): Bucket;
+
+  /** Bucket for the configured `content` bus. */
+  contentBus(disableR2?: boolean): Bucket;
+
+  /** Bucket for the configured `code` bus. */
+  codeBus(disableR2?: boolean): Bucket;
 
   /**
-   * @param disableR2 whether to disable writing to R2
-   * @returns {Bucket}
+   * Bucket for the configured `source` bus. R2 mirroring defaults to disabled here,
+   * since the source bus is typically not mirrored.
    */
-  contentBus(disableR2: boolean = false): Bucket;
+  sourceBus(disableR2?: boolean): Bucket;
 
-  /**
-   * @param disableR2 whether to disable writing to R2
-   * @returns {Bucket}
-   */
-  codeBus(disableR2: boolean = false): Bucket;
-
-  /**
-   * @param disableR2 whether to disable writing to R2
-   * @returns {Bucket}
-   */
-  sourceBus(disableR2: boolean = true): Bucket;
-
-  /**
-   * @returns {Bucket}
-   */
+  /** Bucket for the configured `media` bus. R2 mirroring is always disabled. */
   mediaBus(): Bucket;
 
-  /**
-   * @returns {Bucket}
-   */
+  /** Bucket for the configured `config` bus. R2 mirroring is always disabled. */
   configBus(): Bucket;
 
   /**
-   * Close this storage. Destroys the S3 client used.
+   * Close this storage. Destroys the underlying S3 (and R2) clients and renders this
+   * instance unusable.
    */
   close(): void;
 }

--- a/packages/helix-shared-storage/src/storage.d.ts
+++ b/packages/helix-shared-storage/src/storage.d.ts
@@ -34,13 +34,6 @@ export interface ObjectInfo {
   /** absolute object key. For folders, S3's `CommonPrefix` value (ends with `/`). */
   key: string;
   /**
-   * Path relative to the listing's `prefix` argument. Always starts with
-   * `/` and never ends with `/` — the {@link ObjectInfo.isFolder} flag
-   * carries the file/folder distinction. The same form the caller would
-   * pass back as the `path` argument to drill into a folder.
-   */
-  path: string;
-  /**
    * Basename of the entry — the last path segment, with any trailing `/`
    * stripped. E.g. `2024` for a folder `/blog/2024/`, `post.md` for an
    * object key `/blog/post.md`.
@@ -111,6 +104,11 @@ export interface ListOptions {
  * when {@link Bucket.browse} hits a truncated S3 response.
  */
 export interface ListResult {
+  /**
+   * The sanitized S3 prefix that was actually queried (always ends with `/`,
+   * or is `''` when the whole bucket was listed).
+   */
+  prefix: string;
   /** the page of entries (files and, for shallow listings, folders) */
   objects: ObjectInfo[];
   /** continuation token to pass back to {@link Bucket.browse} for the next page */
@@ -318,49 +316,45 @@ export declare interface Bucket {
   ): Promise<BulkDeleteResult>;
 
   /**
-   * Auto-paginated listing of entries below `prefix + path`.
+   * Auto-paginated listing of entries below `prefix`.
    *
-   * `prefix` is the fixed root of the subtree; `path` is the subdirectory
-   * within it (always interpreted as a directory: normalized to start *and*
-   * end with `/`). When `shallow: true`, common prefixes (folders directly
-   * below the listed dir) are returned alongside files; callers filter by
-   * `isFolder` if they want only one kind. Each returned `ObjectInfo.path`
-   * is relative to `prefix`.
+   * `prefix` is the key prefix of the subtree to list; it is normalized to
+   * canonical S3 form (no leading `/`, always a trailing `/` for non-empty
+   * values). When `shallow: true`, common prefixes (folders directly below the
+   * prefix) are returned alongside files; callers filter by `isFolder` if they
+   * want only one kind. The sanitized prefix used for the S3 query is included
+   * in the returned {@link ListResult} as `prefix`.
    *
-   * @param prefix root of the subtree to list under
-   * @param path subdirectory within `prefix`. Defaults to `'/'`.
+   * @param prefix key prefix to list under (leading/trailing `/` are normalised)
    */
-  list(prefix: string, path?: string, opts?: ListOptions): Promise<ListResult>;
+  list(prefix: string, opts?: ListOptions): Promise<ListResult>;
 
   /**
    * Convenience wrapper around {@link Bucket.list} that returns only the
-   * folder paths directly below `prefix + path`. Equivalent to
-   * `(await list(prefix, path, { shallow: true })).objects.filter(o => o.isFolder).map(o => o.path)`.
+   * basenames of folders directly below `prefix`. Equivalent to
+   * `(await list(prefix, { shallow: true })).objects.filter(o => o.isFolder).map(o => o.name)`.
    *
-   * @param prefix root of the subtree
-   * @param path subdirectory within `prefix`. Defaults to `'/'`.
-   * @returns folder paths, each relative to `prefix`, starting with `/`,
-   *  never ending with `/`
+   * @param prefix key prefix to list under (leading/trailing `/` are normalised)
+   * @returns folder basenames (e.g. `['2024', 'drafts']`)
    */
-  listFolders(prefix: string, path?: string): Promise<string[]>;
+  listFolders(prefix: string): Promise<string[]>;
 
   /**
    * Single-page, always-shallow listing intended for paginated UI browsing.
    *
-   * Same `prefix` / `path` conventions as {@link Bucket.list}. Unlike `list`,
-   * `browse` does not auto-page: it issues one `ListObjectsV2` call, returns
-   * the entries it received, and exposes the `NextContinuationToken` (if
-   * any) so the caller can request the next page on demand. `maxItems`
+   * `prefix` is normalised the same way as for {@link Bucket.list}. Unlike
+   * `list`, `browse` does not auto-page: it issues one `ListObjectsV2` call,
+   * returns the entries it received, and exposes the `NextContinuationToken`
+   * (if any) so the caller can request the next page on demand. `maxItems`
    * controls the page size only.
    *
-   * Each returned `ObjectInfo.path` is in the same form as the `path`
-   * argument, so the caller can pass an entry's `path` straight back to
-   * drill in.
+   * The sanitized prefix is included in the returned {@link ListResult} as
+   * `prefix`. To drill into a folder, append the folder's `name` to the
+   * current `prefix` and call `browse` again.
    *
-   * @param prefix root of the subtree being browsed
-   * @param path subdirectory within `prefix` to list. Defaults to `'/'`.
+   * @param prefix key prefix to browse (leading/trailing `/` are normalised)
    */
-  browse(prefix: string, path?: string, opts?: BrowseOptions): Promise<ListResult>;
+  browse(prefix: string, opts?: BrowseOptions): Promise<ListResult>;
 
   /**
    * Copies the tree below `src` to `dst`. Concurrency is fixed at 64; per-object errors are
@@ -377,7 +371,6 @@ export declare interface Bucket {
   ): Promise<Array<{
     src: string;
     dst: string;
-    path: string;
     contentLength?: number;
     contentType?: string | null;
   }>>;

--- a/packages/helix-shared-storage/src/storage.d.ts
+++ b/packages/helix-shared-storage/src/storage.d.ts
@@ -68,6 +68,35 @@ export interface CopyOptions {
   copyOpts?: Partial<CopyObjectCommandInput>;
 }
 
+export interface BrowseOptions {
+  /**
+   * Continuation token returned by a previous {@link Bucket.browse} call.
+   * Pass it back unchanged to fetch the next page; omit to start from the
+   * beginning of the listing.
+   */
+  continuationToken?: string;
+  /**
+   * Maximum number of entries to return in this page (S3 `MaxKeys`). Capped
+   * at 1000 by S3; defaults to the S3 default when omitted.
+   */
+  maxItems?: number;
+  /**
+   * Whether to include common prefixes (subfolders) as entries in the result.
+   * Defaults to `true`, since browsing typically wants folder-style navigation.
+   */
+  includePrefixes?: boolean;
+}
+
+export interface BrowseResult {
+  /** the page of objects (and, when {@link BrowseOptions.includePrefixes}, common prefixes) */
+  objects: ObjectInfo[];
+  /**
+   * Continuation token to pass back to {@link Bucket.browse} to fetch the next
+   * page. `undefined` when the listing has been exhausted.
+   */
+  continuationToken?: string;
+}
+
 export interface ListOptions {
   /** whether to list shallow, i.e. not recursive (uses `/` as delimiter). Default `false`. */
   shallow?: boolean;
@@ -290,6 +319,17 @@ export declare interface Bucket {
    * List the common prefixes (subfolders) directly below `prefix`. Always shallow.
    */
   listFolders(prefix: string): Promise<string[]>;
+
+  /**
+   * Single-page, always-shallow listing intended for paginated UI browsing.
+   *
+   * Unlike {@link Bucket.list}, `browse` does not auto-page through the result:
+   * it issues one `ListObjectsV2` call, returns the entries it received, and
+   * exposes the `NextContinuationToken` (if any) so the caller can request the
+   * next page when the user navigates forward. `maxItems` controls the page
+   * size only.
+   */
+  browse(prefix: string, opts?: BrowseOptions): Promise<BrowseResult>;
 
   /**
    * Copies the tree below `src` to `dst`. Concurrency is fixed at 64; per-object errors are

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -104,22 +104,43 @@ function sanitizeKey(keyOrPath) {
 }
 
 /**
+ * Returns the last segment of a key, treating an optional trailing `/` as a
+ * folder separator. E.g. `/blog/2024/post.md` → `post.md`,
+ * `/blog/2024/` → `2024`, `foo` → `foo`.
+ *
+ * @param {string} key
+ * @returns {string}
+ */
+function basename(key) {
+  const trimmed = key.endsWith('/') ? key.slice(0, -1) : key;
+  const slash = trimmed.lastIndexOf('/');
+  return slash >= 0 ? trimmed.substring(slash + 1) : trimmed;
+}
+
+/**
  * Map a `ListObjectsV2` response into {@link ObjectInfo} entries. Used by both
  * {@link Bucket#list} (which calls it once per page) and {@link Bucket#browse}.
  *
+ * The `path` field on each entry is computed by stripping `pathBase` from the
+ * front of the entry's key. Pass the listed prefix as `pathBase` to get
+ * paths relative to the listing (the {@link Bucket#list} convention); pass a
+ * fixed root as `pathBase` to get paths relative to that root regardless of
+ * how deep the listing is (the {@link Bucket#browse} convention).
+ *
  * @param {object} result the `ListObjectsV2Command` response
- * @param {string} prefix the listing prefix; subtracted from each entry's `key`
- *  to compute its `path`
+ * @param {string} pathBase prefix to strip from each entry's `key` to compute
+ *  its `path`
  * @param {boolean} includePrefixes whether to include common prefixes (folders)
  * @returns {ObjectInfo[]}
  */
-function listResultToObjectInfos(result, prefix, includePrefixes) {
+function listResultToObjectInfos(result, pathBase, includePrefixes) {
   const objects = [];
   if (includePrefixes) {
     (result.CommonPrefixes || []).forEach(({ Prefix }) => {
       objects.push({
         key: Prefix,
-        path: `${Prefix.substring(prefix.length)}`,
+        path: `${Prefix.substring(pathBase.length)}`,
+        name: basename(Prefix),
       });
     });
   }
@@ -130,7 +151,8 @@ function listResultToObjectInfos(result, prefix, includePrefixes) {
       lastModified: content.LastModified,
       contentLength: content.Size,
       contentType: mime.getType(key),
-      path: `${key.substring(prefix.length)}`,
+      path: `${key.substring(pathBase.length)}`,
+      name: basename(key),
     });
   });
   return objects;
@@ -650,32 +672,56 @@ class Bucket {
   /**
    * Single-page, always-shallow listing intended for paginated UI browsing.
    *
-   * Unlike {@link Bucket#list}, this does not auto-page: it issues one
-   * `ListObjectsV2` call (with `Delimiter: '/'`), returns the entries it
-   * received, and exposes the `NextContinuationToken` so the caller can request
-   * the next page on demand. `maxItems` controls the page size only.
+   * `prefix` is the fixed *root* of the subtree being browsed; it does not
+   * change as the user navigates. `path` is the *subdirectory* within that
+   * root currently being listed; the actual S3 prefix sent is `prefix + path`.
+   * The returned `path` on each entry is always relative to `prefix` (i.e. it
+   * starts with `/` and contains the navigated `path`), so the caller can
+   * pass an entry's `path` straight back as the next call's `path` argument
+   * without having to reconstruct breadcrumbs.
    *
-   * @param {string} prefix
+   * `path` is normalized to start with `/` (and `prefix`'s trailing `/`, if
+   * any, is stripped before concatenation). For example:
+   *
+   * ```js
+   * const ROOT = 'owner/repo/main/';
+   * const r1 = await bus.browse(ROOT, '/');
+   * // r1.objects[i].path -> '/blog/', '/images/', '/index.md', ...
+   * const r2 = await bus.browse(ROOT, '/blog/');
+   * // r2.objects[i].path -> '/blog/2024/', '/blog/index.md', ...
+   * ```
+   *
+   * Unlike {@link Bucket#list}, this does not auto-page: it issues one
+   * `ListObjectsV2` call, returns the entries it received, and exposes the
+   * `NextContinuationToken` so the caller can request the next page on
+   * demand. `maxItems` controls the page size only.
+   *
+   * @param {string} prefix root of the subtree being browsed
+   * @param {string} [path] subdirectory within `prefix` to list; defaults to
+   *  `'/'`. Normalized to start with `/`.
    * @param {BrowseOptions} [opts]
    * @returns {Promise<BrowseResult>}
    */
-  async browse(prefix, opts = {}) {
+  async browse(prefix, path = '/', opts = {}) {
     const {
       continuationToken,
       maxItems,
       includePrefixes = true,
     } = opts;
 
+    const root = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+    const subPath = path.startsWith('/') ? path : `/${path}`;
+
     const result = await this.client.send(new ListObjectsV2Command({
       Bucket: this.bucket,
-      Prefix: prefix,
+      Prefix: `${root}${subPath}`,
       Delimiter: '/',
       ContinuationToken: continuationToken || undefined,
       MaxKeys: maxItems,
     }));
 
     return {
-      objects: listResultToObjectInfos(result, prefix, includePrefixes),
+      objects: listResultToObjectInfos(result, root, includePrefixes),
       continuationToken: result.IsTruncated ? result.NextContinuationToken : undefined,
     };
   }

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -103,6 +103,39 @@ function sanitizeKey(keyOrPath) {
   return keyOrPath;
 }
 
+/**
+ * Map a `ListObjectsV2` response into {@link ObjectInfo} entries. Used by both
+ * {@link Bucket#list} (which calls it once per page) and {@link Bucket#browse}.
+ *
+ * @param {object} result the `ListObjectsV2Command` response
+ * @param {string} prefix the listing prefix; subtracted from each entry's `key`
+ *  to compute its `path`
+ * @param {boolean} includePrefixes whether to include common prefixes (folders)
+ * @returns {ObjectInfo[]}
+ */
+function listResultToObjectInfos(result, prefix, includePrefixes) {
+  const objects = [];
+  if (includePrefixes) {
+    (result.CommonPrefixes || []).forEach(({ Prefix }) => {
+      objects.push({
+        key: Prefix,
+        path: `${Prefix.substring(prefix.length)}`,
+      });
+    });
+  }
+  (result.Contents || []).forEach((content) => {
+    const key = content.Key;
+    objects.push({
+      key,
+      lastModified: content.LastModified,
+      contentLength: content.Size,
+      contentType: mime.getType(key),
+      path: `${key.substring(prefix.length)}`,
+    });
+  });
+  return objects;
+}
+
 const BUCKET_KEYS = ['config', 'code', 'content', 'media', 'source'];
 
 /**
@@ -609,26 +642,7 @@ class Bucket {
       // eslint-disable-next-line no-await-in-loop
       const result = await this.client.send(new ListObjectsV2Command(input));
       ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
-
-      if (includePrefixes) {
-        (result.CommonPrefixes || []).forEach(({ Prefix }) => {
-          objects.push({
-            key: Prefix,
-            path: `${Prefix.substring(prefix.length)}`,
-          });
-        });
-      }
-
-      (result.Contents || []).forEach((content) => {
-        const key = content.Key;
-        objects.push({
-          key,
-          lastModified: content.LastModified,
-          contentLength: content.Size,
-          contentType: mime.getType(key),
-          path: `${key.substring(prefix.length)}`,
-        });
-      });
+      objects.push(...listResultToObjectInfos(result, prefix, includePrefixes));
     } while (ContinuationToken && objects.length < maxItems);
     return objects;
   }
@@ -660,28 +674,8 @@ class Bucket {
       MaxKeys: maxItems,
     }));
 
-    const objects = [];
-    if (includePrefixes) {
-      (result.CommonPrefixes || []).forEach(({ Prefix }) => {
-        objects.push({
-          key: Prefix,
-          path: `${Prefix.substring(prefix.length)}`,
-        });
-      });
-    }
-    (result.Contents || []).forEach((content) => {
-      const key = content.Key;
-      objects.push({
-        key,
-        lastModified: content.LastModified,
-        contentLength: content.Size,
-        contentType: mime.getType(key),
-        path: `${key.substring(prefix.length)}`,
-      });
-    });
-
     return {
-      objects,
+      objects: listResultToObjectInfos(result, prefix, includePrefixes),
       continuationToken: result.IsTruncated ? result.NextContinuationToken : undefined,
     };
   }

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -55,6 +55,8 @@ const MAX_DELETE_OBJECTS = 1000;
  * @typedef {import('./storage.d').ObjectFilter} ObjectFilter
  * @typedef {import('./storage.d').CopyOptions} CopyOptions
  * @typedef {import('./storage.d').ListOptions} ListOptions
+ * @typedef {import('./storage.d').BrowseOptions} BrowseOptions
+ * @typedef {import('./storage.d').BrowseResult} BrowseResult
  */
 
 /**
@@ -629,6 +631,59 @@ class Bucket {
       });
     } while (ContinuationToken && objects.length < maxItems);
     return objects;
+  }
+
+  /**
+   * Single-page, always-shallow listing intended for paginated UI browsing.
+   *
+   * Unlike {@link Bucket#list}, this does not auto-page: it issues one
+   * `ListObjectsV2` call (with `Delimiter: '/'`), returns the entries it
+   * received, and exposes the `NextContinuationToken` so the caller can request
+   * the next page on demand. `maxItems` controls the page size only.
+   *
+   * @param {string} prefix
+   * @param {BrowseOptions} [opts]
+   * @returns {Promise<BrowseResult>}
+   */
+  async browse(prefix, opts = {}) {
+    const {
+      continuationToken,
+      maxItems,
+      includePrefixes = true,
+    } = opts;
+
+    const result = await this.client.send(new ListObjectsV2Command({
+      Bucket: this.bucket,
+      Prefix: prefix,
+      Delimiter: '/',
+      ContinuationToken: continuationToken || undefined,
+      MaxKeys: maxItems,
+    }));
+
+    const objects = [];
+    if (includePrefixes) {
+      (result.CommonPrefixes || []).forEach(({ Prefix }) => {
+        objects.push({
+          key: Prefix,
+          path: `${Prefix.substring(prefix.length)}`,
+        });
+      });
+    }
+    (result.Contents || []).forEach((content) => {
+      const key = content.Key;
+      objects.push({
+        key,
+        lastModified: content.LastModified,
+        contentLength: content.Size,
+        contentType: mime.getType(key),
+        path: `${key.substring(prefix.length)}`,
+      });
+    });
+
+    return {
+      objects,
+      continuationToken: result.IsTruncated ? result.NextContinuationToken : undefined,
+    };
   }
 
   /**

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -118,11 +118,22 @@ function sanitizeKey(keyOrPath) {
  * @returns {string}
  */
 function ensureDirPath(path) {
-  let p = path.startsWith('/') ? path : `/${path}`;
-  if (!p.endsWith('/')) {
+  let p = path.charAt(0) === '/' ? path : `/${path}`;
+  if (p.charAt(p.length - 1) !== '/') {
     p += '/';
   }
   return p;
+}
+
+/**
+ * Strip a leading `/` if present. Used after concatenating a (possibly
+ * empty) root with a leading-slashed path to produce a canonical S3 key.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function stripLeadingSlash(s) {
+  return s.charAt(0) === '/' ? s.substring(1) : s;
 }
 
 /**
@@ -683,8 +694,8 @@ class Bucket {
     const dir = ensureDirPath(path);
     // strip any leading `/` from the concatenation: it only appears when
     // `root` is empty (canonical S3 keys don't start with `/`).
-    const Prefix = `${root}${dir}`.replace(/^\//, '');
-    const pathBase = `${root}/`.replace(/^\//, '');
+    const Prefix = stripLeadingSlash(`${root}${dir}`);
+    const pathBase = stripLeadingSlash(`${root}/`);
 
     let ContinuationToken;
     const objects = [];
@@ -743,8 +754,8 @@ class Bucket {
     const { continuationToken, maxItems } = opts;
     const root = sanitizeKey(prefix);
     const dir = ensureDirPath(path);
-    const Prefix = `${root}${dir}`.replace(/^\//, '');
-    const pathBase = `${root}/`.replace(/^\//, '');
+    const Prefix = stripLeadingSlash(`${root}${dir}`);
+    const pathBase = stripLeadingSlash(`${root}/`);
 
     const result = await this.client.send(new ListObjectsV2Command({
       Bucket: this.bucket,
@@ -801,7 +812,7 @@ class Bucket {
           // `dstRoot` the leading `/` acts as the separator, for empty
           // `dstRoot` (copying to the bucket root) we'd otherwise end up
           // with a non-canonical S3 key.
-          dst: `${dstRoot}${path}`.replace(/^\//, ''),
+          dst: stripLeadingSlash(`${dstRoot}${path}`),
         });
       }
     });

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -140,7 +140,7 @@ function listResultToObjectInfos(result, pathBase, includePrefixes) {
     (result.CommonPrefixes || []).forEach(({ Prefix }) => {
       objects.push({
         key: Prefix,
-        path: `${Prefix.substring(baseLen)}`,
+        path: Prefix.substring(baseLen),
         name: basename(Prefix),
       });
     });
@@ -152,7 +152,7 @@ function listResultToObjectInfos(result, pathBase, includePrefixes) {
       lastModified: content.LastModified,
       contentLength: content.Size,
       contentType: mime.getType(key),
-      path: `${key.substring(baseLen)}`,
+      path: key.substring(baseLen),
       name: basename(key),
     });
   });

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -92,15 +92,37 @@ const METADATA_HEADER_MAP = new Map([
 ]);
 
 /**
- * Sanitizes the input key or path and returns a bucket relative key (without leading / ).
+ * Sanitizes the input key or path and returns a canonical S3 form: no
+ * leading and no trailing `/`.
+ *
  * @param {string} keyOrPath
  * @returns {string}
  */
 function sanitizeKey(keyOrPath) {
-  if (keyOrPath.charAt(0) === '/') {
-    return keyOrPath.substring(1);
+  let s = keyOrPath;
+  if (s.startsWith('/')) {
+    s = s.substring(1);
   }
-  return keyOrPath;
+  if (s.endsWith('/')) {
+    s = s.slice(0, -1);
+  }
+  return s;
+}
+
+/**
+ * Normalize a directory-style path: ensures it starts *and* ends with `/`.
+ * Used when building an S3 list prefix from a `prefix + path` pair where
+ * `path` is always interpreted as a directory.
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+function ensureDirPath(path) {
+  let p = path.startsWith('/') ? path : `/${path}`;
+  if (!p.endsWith('/')) {
+    p += '/';
+  }
+  return p;
 }
 
 /**
@@ -115,30 +137,6 @@ function basename(key) {
   const trimmed = key.endsWith('/') ? key.slice(0, -1) : key;
   const slash = trimmed.lastIndexOf('/');
   return slash >= 0 ? trimmed.substring(slash + 1) : trimmed;
-}
-
-/**
- * Normalize the `prefix` + `path` arguments shared by {@link Bucket#list}
- * and {@link Bucket#browse} into:
- * - `root`: `prefix` with any leading and trailing `/` stripped — the
- *   strip-base for computing each entry's root-relative `path`. Stripped
- *   to canonical S3 form (S3 keys don't start with `/`).
- * - `dir`: the path argument, always interpreted as a directory (starts
- *   with `/` and ends with `/`).
- *
- * The actual S3 prefix sent for the listing is `root + dir`.
- *
- * @param {string} prefix
- * @param {string} path
- * @returns {{ root: string, dir: string }}
- */
-function normalizePrefixAndPath(prefix, path) {
-  const root = sanitizeKey(prefix).replace(/\/$/, '');
-  let dir = path.startsWith('/') ? path : `/${path}`;
-  if (!dir.endsWith('/')) {
-    dir += '/';
-  }
-  return { root, dir };
 }
 
 /**
@@ -679,7 +677,8 @@ class Bucket {
    */
   async list(prefix, path = '/', opts = {}) {
     const { shallow = false, maxItems = Number.POSITIVE_INFINITY } = opts;
-    const { root, dir } = normalizePrefixAndPath(prefix, path);
+    const root = sanitizeKey(prefix);
+    const dir = ensureDirPath(path);
 
     let ContinuationToken;
     const objects = [];
@@ -736,7 +735,8 @@ class Bucket {
    */
   async browse(prefix, path = '/', opts = {}) {
     const { continuationToken, maxItems } = opts;
-    const { root, dir } = normalizePrefixAndPath(prefix, path);
+    const root = sanitizeKey(prefix);
+    const dir = ensureDirPath(path);
 
     const result = await this.client.send(new ListObjectsV2Command({
       Bucket: this.bucket,
@@ -773,11 +773,11 @@ class Bucket {
     const { log } = this;
     const tasks = [];
     const Prefix = sanitizeKey(src);
-    // strip trailing `/` from dst so we can concatenate with `path` which
-    // is root-relative and always starts with `/`
-    const dstPrefix = sanitizeKey(dst);
-    const dstRoot = dstPrefix.replace(/\/$/, '');
-    this.log.info(`fetching list of files to copy ${this.bucket}/${Prefix} => ${dstPrefix}`);
+    // dst is sanitized to canonical form (no leading/trailing `/`) so it
+    // can be concatenated with `path`, which is root-relative and always
+    // starts with `/`.
+    const dstRoot = sanitizeKey(dst);
+    this.log.info(`fetching list of files to copy ${this.bucket}/${Prefix} => ${dstRoot}`);
     const { objects } = await this.list(Prefix);
     objects.forEach((obj) => {
       const {

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -56,7 +56,7 @@ const MAX_DELETE_OBJECTS = 1000;
  * @typedef {import('./storage.d').CopyOptions} CopyOptions
  * @typedef {import('./storage.d').ListOptions} ListOptions
  * @typedef {import('./storage.d').BrowseOptions} BrowseOptions
- * @typedef {import('./storage.d').BrowseResult} BrowseResult
+ * @typedef {import('./storage.d').ListResult} ListResult
  */
 
 /**
@@ -118,42 +118,65 @@ function basename(key) {
 }
 
 /**
+ * Normalize the `prefix` + `path` arguments shared by {@link Bucket#list}
+ * and {@link Bucket#browse} into:
+ * - `root`: `prefix` with any trailing `/` stripped — the strip-base for
+ *   computing each entry's root-relative `path`.
+ * - `dir`: the path argument, always interpreted as a directory (starts
+ *   with `/` and ends with `/`).
+ *
+ * The actual S3 prefix sent for the listing is `root + dir`.
+ *
+ * @param {string} prefix
+ * @param {string} path
+ * @returns {{ root: string, dir: string }}
+ */
+function normalizePrefixAndPath(prefix, path) {
+  const root = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  let dir = path.startsWith('/') ? path : `/${path}`;
+  if (!dir.endsWith('/')) {
+    dir += '/';
+  }
+  return { root, dir };
+}
+
+/**
  * Map a `ListObjectsV2` response into {@link ObjectInfo} entries. Used by both
- * {@link Bucket#list} (which calls it once per page) and {@link Bucket#browse}.
+ * {@link Bucket#list} and {@link Bucket#browse}; the `Delimiter` setting on
+ * the underlying request determines whether `CommonPrefixes` are present.
  *
  * The `path` field on each entry is computed by stripping `pathBase` from the
- * front of the entry's key. Pass the listed prefix as `pathBase` to get
- * paths relative to the listing (the {@link Bucket#list} convention); pass a
- * fixed root as `pathBase` to get paths relative to that root regardless of
- * how deep the listing is (the {@link Bucket#browse} convention).
+ * front of the entry's key, and any trailing `/` (for common prefixes) is
+ * dropped — every `path` value is uniform: starts with `/`, never ends with
+ * `/`. The `isFolder` flag carries the file/folder distinction.
  *
  * @param {object} result the `ListObjectsV2Command` response
  * @param {string} pathBase prefix to strip from each entry's `key` to compute
  *  its `path`
- * @param {boolean} includePrefixes whether to include common prefixes (folders)
  * @returns {ObjectInfo[]}
  */
-function listResultToObjectInfos(result, pathBase, includePrefixes) {
+function listResultToObjectInfos(result, pathBase) {
   const baseLen = pathBase.length;
   const objects = [];
-  if (includePrefixes) {
-    (result.CommonPrefixes || []).forEach(({ Prefix }) => {
-      objects.push({
-        key: Prefix,
-        path: Prefix.substring(baseLen),
-        name: basename(Prefix),
-      });
+  (result.CommonPrefixes || []).forEach(({ Prefix }) => {
+    objects.push({
+      key: Prefix,
+      // S3 always returns CommonPrefix values ending with `/`; drop it.
+      path: Prefix.substring(baseLen).replace(/\/$/, ''),
+      name: basename(Prefix),
+      isFolder: true,
     });
-  }
+  });
   (result.Contents || []).forEach((content) => {
     const key = content.Key;
     objects.push({
       key,
+      path: key.substring(baseLen),
+      name: basename(key),
+      isFolder: false,
       lastModified: content.LastModified,
       contentLength: content.Size,
       contentType: mime.getType(key),
-      path: key.substring(baseLen),
-      name: basename(key),
     });
   });
   return objects;
@@ -637,18 +660,25 @@ class Bucket {
   }
 
   /**
-   * List objects below `prefix`. Pages through `ListObjectsV2` until the result
-   * is no longer truncated or `maxItems` is reached.
+   * List objects below `prefix + path`. Pages through `ListObjectsV2` until the
+   * result is no longer truncated or `maxItems` is reached.
    *
-   * @param {string} prefix the key prefix to list under
-   * @param {boolean|ListOptions} [opts] list options. As a backward-compatibility
-   *  shortcut, passing `true` is equivalent to `{ shallow: true }`.
-   * @returns {Promise<ObjectInfo[]>}
+   * `prefix` is the fixed root of the subtree; `path` is the subdirectory
+   * within it (always interpreted as a directory: normalized to start *and*
+   * end with `/`). Each returned `ObjectInfo.path` is relative to `prefix`,
+   * starts with `/`, and never ends with `/` — the `isFolder` flag carries
+   * the file/folder distinction. When `shallow: true`, common prefixes
+   * (folders directly below the listed dir) are returned alongside files;
+   * callers filter by `isFolder` if they want only one kind.
+   *
+   * @param {string} prefix root of the subtree to list under
+   * @param {string} [path] subdirectory within `prefix`. Defaults to `'/'`.
+   * @param {ListOptions} [opts]
+   * @returns {Promise<ListResult>}
    */
-  async list(prefix, opts = false) {
-    const {
-      shallow = false, maxItems = Number.POSITIVE_INFINITY, includePrefixes = false,
-    } = typeof opts === 'boolean' ? { shallow: opts } : opts;
+  async list(prefix, path = '/', opts = {}) {
+    const { shallow = false, maxItems = Number.POSITIVE_INFINITY } = opts;
+    const { root, dir } = normalizePrefixAndPath(prefix, path);
 
     let ContinuationToken;
     const objects = [];
@@ -656,7 +686,7 @@ class Bucket {
       const input = {
         Bucket: this.bucket,
         ContinuationToken,
-        Prefix: prefix,
+        Prefix: `${root}${dir}`,
         Delimiter: shallow ? '/' : undefined,
       };
       if (maxItems - objects.length < 1000) {
@@ -665,31 +695,31 @@ class Bucket {
       // eslint-disable-next-line no-await-in-loop
       const result = await this.client.send(new ListObjectsV2Command(input));
       ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
-      objects.push(...listResultToObjectInfos(result, prefix, includePrefixes));
+      objects.push(...listResultToObjectInfos(result, root));
     } while (ContinuationToken && objects.length < maxItems);
-    return objects;
+    return { objects, continuationToken: undefined };
   }
 
   /**
    * Single-page, always-shallow listing intended for paginated UI browsing.
    *
-   * `prefix` is the fixed *root* of the subtree being browsed; it does not
-   * change as the user navigates. `path` is the *subdirectory* within that
-   * root currently being listed; the actual S3 prefix sent is `prefix + path`.
-   * The returned `path` on each entry is always relative to `prefix` (i.e. it
-   * starts with `/` and contains the navigated `path`), so the caller can
-   * pass an entry's `path` straight back as the next call's `path` argument
-   * without having to reconstruct breadcrumbs.
+   * `prefix` is the fixed root (constant during navigation); `path` is the
+   * subdirectory within it (always interpreted as a directory: normalized
+   * to start *and* end with `/`). The actual S3 prefix sent is
+   * `prefix + path`. Each returned `ObjectInfo.path` is relative to
+   * `prefix`, starts with `/`, and never ends with `/`; the `isFolder` flag
+   * carries the file/folder distinction. The caller can pass an entry's
+   * `path` straight back as the next call's `path` argument to drill in
+   * without reconstructing breadcrumbs.
    *
-   * `path` is normalized to start with `/` (and `prefix`'s trailing `/`, if
-   * any, is stripped before concatenation). For example:
+   * Example:
    *
    * ```js
    * const ROOT = 'owner/repo/main/';
-   * const r1 = await bus.browse(ROOT, '/');
-   * // r1.objects[i].path -> '/blog/', '/images/', '/index.md', ...
-   * const r2 = await bus.browse(ROOT, '/blog/');
-   * // r2.objects[i].path -> '/blog/2024/', '/blog/index.md', ...
+   * const r1 = await bus.browse(ROOT);
+   * // r1.objects[i].path -> '/blog', '/images', '/index.md', ...
+   * const r2 = await bus.browse(ROOT, r1.objects[0].path); // '/blog'
+   * // r2.objects[i].path -> '/blog/2024', '/blog/index.md', ...
    * ```
    *
    * Unlike {@link Bucket#list}, this does not auto-page: it issues one
@@ -698,62 +728,29 @@ class Bucket {
    * demand. `maxItems` controls the page size only.
    *
    * @param {string} prefix root of the subtree being browsed
-   * @param {string} [path] subdirectory within `prefix` to list; defaults to
-   *  `'/'`. Normalized to start with `/`.
+   * @param {string} [path] subdirectory within `prefix` to list. Defaults
+   *  to `'/'`.
    * @param {BrowseOptions} [opts]
-   * @returns {Promise<BrowseResult>}
+   * @returns {Promise<ListResult>}
    */
   async browse(prefix, path = '/', opts = {}) {
-    const {
-      continuationToken,
-      maxItems,
-      includePrefixes = true,
-    } = opts;
-
-    const root = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
-    const subPath = path.startsWith('/') ? path : `/${path}`;
+    const { continuationToken, maxItems } = opts;
+    const { root, dir } = normalizePrefixAndPath(prefix, path);
 
     const result = await this.client.send(new ListObjectsV2Command({
       Bucket: this.bucket,
-      Prefix: `${root}${subPath}`,
+      Prefix: `${root}${dir}`,
       Delimiter: '/',
       ContinuationToken: continuationToken || undefined,
       MaxKeys: maxItems,
     }));
 
     return {
-      objects: listResultToObjectInfos(result, root, includePrefixes),
+      objects: listResultToObjectInfos(result, root),
       continuationToken: result.IsTruncated
         ? result.NextContinuationToken
         : undefined,
     };
-  }
-
-  /**
-   * List the common prefixes (subfolders) directly below `prefix`. Equivalent
-   * to a `ListObjectsV2` with `Delimiter: '/'`, returning only the
-   * `CommonPrefixes` aggregated across pages.
-   *
-   * @param {string} prefix
-   * @returns {Promise<string[]>} the list of common prefixes (each ending with `/`)
-   */
-  async listFolders(prefix) {
-    let ContinuationToken;
-    const folders = [];
-    do {
-      // eslint-disable-next-line no-await-in-loop
-      const result = await this.client.send(new ListObjectsV2Command({
-        Bucket: this.bucket,
-        ContinuationToken,
-        Prefix: prefix,
-        Delimiter: '/',
-      }));
-      ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
-      (result.CommonPrefixes || []).forEach(({ Prefix }) => {
-        folders.push(Prefix);
-      });
-    } while (ContinuationToken);
-    return folders;
   }
 
   /**
@@ -775,9 +772,13 @@ class Bucket {
     const { log } = this;
     const tasks = [];
     const Prefix = sanitizeKey(src);
+    // strip trailing `/` from dst so we can concatenate with `path` which
+    // is root-relative and always starts with `/`
     const dstPrefix = sanitizeKey(dst);
+    const dstRoot = dstPrefix.replace(/\/$/, '');
     this.log.info(`fetching list of files to copy ${this.bucket}/${Prefix} => ${dstPrefix}`);
-    (await this.list(Prefix)).forEach((obj) => {
+    const { objects } = await this.list(Prefix);
+    objects.forEach((obj) => {
       const {
         path, key, contentLength, contentType,
       } = obj;
@@ -787,7 +788,7 @@ class Bucket {
           path,
           contentLength,
           contentType,
-          dst: `${dstPrefix}${path}`,
+          dst: `${dstRoot}${path}`,
         });
       }
     });
@@ -844,8 +845,8 @@ class Bucket {
   async rmdir(src) {
     src = sanitizeKey(src);
     this.log.info(`fetching list of files to delete from ${this.bucket}/${src}`);
-    const items = await this.list(src);
-    return this.remove(items.map((item) => item.key), src);
+    const { objects } = await this.list(src);
+    return this.remove(objects.map((item) => item.key), src);
   }
 }
 

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -785,7 +785,9 @@ class Bucket {
    */
   async listFolders(prefix, path = '/') {
     const { objects } = await this.list(prefix, path, { shallow: true });
-    return objects.filter((o) => o.isFolder).map((o) => o.path);
+    return objects
+      .filter((o) => o.isFolder)
+      .map((o) => o.path);
   }
 
   /**
@@ -808,8 +810,7 @@ class Bucket {
     const tasks = [];
     const Prefix = sanitizeKey(src);
     // dst is sanitized to canonical form (no leading/trailing `/`) so it
-    // can be concatenated with `path`, which is root-relative and always
-    // starts with `/`.
+    // can be concatenated with `path`, which is root-relative and always starts with `/`.
     const dstRoot = sanitizeKey(dst);
     this.log.info(`fetching list of files to copy ${this.bucket}/${Prefix} => ${dstRoot}`);
     const { objects } = await this.list(Prefix);

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -145,13 +145,15 @@ function basename(key) {
  * the underlying request determines whether `CommonPrefixes` are present.
  *
  * The `path` field on each entry is computed by stripping `pathBase` from the
- * front of the entry's key, and any trailing `/` (for common prefixes) is
- * dropped — every `path` value is uniform: starts with `/`, never ends with
- * `/`. The `isFolder` flag carries the file/folder distinction.
+ * front of the entry's key. `pathBase` is `''` when the listing root is the
+ * bucket root, otherwise `${root}/`. A leading `/` is then prepended so every
+ * returned path starts with `/`, and any trailing `/` (for common prefixes)
+ * is dropped — paths are uniform: start with `/`, never end with `/`. The
+ * `isFolder` flag carries the file/folder distinction.
  *
  * @param {object} result the `ListObjectsV2Command` response
  * @param {string} pathBase prefix to strip from each entry's `key` to compute
- *  its `path`
+ *  its `path` (empty string when the listing root is the bucket root)
  * @returns {ObjectInfo[]}
  */
 function listResultToObjectInfos(result, pathBase) {
@@ -161,7 +163,7 @@ function listResultToObjectInfos(result, pathBase) {
     objects.push({
       key: Prefix,
       // S3 always returns CommonPrefix values ending with `/`; drop it.
-      path: Prefix.substring(baseLen).replace(/\/$/, ''),
+      path: `/${Prefix.substring(baseLen).replace(/\/$/, '')}`,
       name: basename(Prefix),
       isFolder: true,
     });
@@ -170,7 +172,7 @@ function listResultToObjectInfos(result, pathBase) {
     const key = content.Key;
     objects.push({
       key,
-      path: key.substring(baseLen),
+      path: `/${key.substring(baseLen)}`,
       name: basename(key),
       isFolder: false,
       lastModified: content.LastModified,
@@ -679,6 +681,10 @@ class Bucket {
     const { shallow = false, maxItems = Number.POSITIVE_INFINITY } = opts;
     const root = sanitizeKey(prefix);
     const dir = ensureDirPath(path);
+    // strip any leading `/` from the concatenation: it only appears when
+    // `root` is empty (canonical S3 keys don't start with `/`).
+    const Prefix = `${root}${dir}`.replace(/^\//, '');
+    const pathBase = `${root}/`.replace(/^\//, '');
 
     let ContinuationToken;
     const objects = [];
@@ -686,7 +692,7 @@ class Bucket {
       const input = {
         Bucket: this.bucket,
         ContinuationToken,
-        Prefix: `${root}${dir}`,
+        Prefix,
         Delimiter: shallow ? '/' : undefined,
       };
       if (maxItems - objects.length < 1000) {
@@ -695,7 +701,7 @@ class Bucket {
       // eslint-disable-next-line no-await-in-loop
       const result = await this.client.send(new ListObjectsV2Command(input));
       ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
-      objects.push(...listResultToObjectInfos(result, root));
+      objects.push(...listResultToObjectInfos(result, pathBase));
     } while (ContinuationToken && objects.length < maxItems);
     return { objects, continuationToken: undefined };
   }
@@ -737,17 +743,19 @@ class Bucket {
     const { continuationToken, maxItems } = opts;
     const root = sanitizeKey(prefix);
     const dir = ensureDirPath(path);
+    const Prefix = `${root}${dir}`.replace(/^\//, '');
+    const pathBase = `${root}/`.replace(/^\//, '');
 
     const result = await this.client.send(new ListObjectsV2Command({
       Bucket: this.bucket,
-      Prefix: `${root}${dir}`,
+      Prefix,
       Delimiter: '/',
       ContinuationToken: continuationToken || undefined,
       MaxKeys: maxItems,
     }));
 
     return {
-      objects: listResultToObjectInfos(result, root),
+      objects: listResultToObjectInfos(result, pathBase),
       continuationToken: result.IsTruncated
         ? result.NextContinuationToken
         : undefined,
@@ -789,7 +797,11 @@ class Bucket {
           path,
           contentLength,
           contentType,
-          dst: `${dstRoot}${path}`,
+          // strip the leading `/` that `path` always carries; for non-empty
+          // `dstRoot` the leading `/` acts as the separator, for empty
+          // `dstRoot` (copying to the bucket root) we'd otherwise end up
+          // with a non-canonical S3 key.
+          dst: `${dstRoot}${path}`.replace(/^\//, ''),
         });
       }
     });

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -134,12 +134,13 @@ function basename(key) {
  * @returns {ObjectInfo[]}
  */
 function listResultToObjectInfos(result, pathBase, includePrefixes) {
+  const baseLen = pathBase.length;
   const objects = [];
   if (includePrefixes) {
     (result.CommonPrefixes || []).forEach(({ Prefix }) => {
       objects.push({
         key: Prefix,
-        path: `${Prefix.substring(pathBase.length)}`,
+        path: `${Prefix.substring(baseLen)}`,
         name: basename(Prefix),
       });
     });
@@ -151,7 +152,7 @@ function listResultToObjectInfos(result, pathBase, includePrefixes) {
       lastModified: content.LastModified,
       contentLength: content.Size,
       contentType: mime.getType(key),
-      path: `${key.substring(pathBase.length)}`,
+      path: `${key.substring(baseLen)}`,
       name: basename(key),
     });
   });

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -110,6 +110,19 @@ function sanitizeKey(keyOrPath) {
 }
 
 /**
+ * Sanitizes a listing prefix: strips leading/trailing `/` then appends a
+ * single trailing `/` for non-empty values, giving canonical S3 directory
+ * form. An empty input returns `''` (list the entire bucket).
+ *
+ * @param {string} prefix
+ * @returns {string}
+ */
+function sanitizePrefix(prefix) {
+  const key = sanitizeKey(prefix);
+  return key ? `${key}/` : '';
+}
+
+/**
  * Returns the last segment of a key, treating an optional trailing `/` as a
  * folder separator. E.g. `/blog/2024/post.md` → `post.md`,
  * `/blog/2024/` → `2024`, `foo` → `foo`.
@@ -642,7 +655,7 @@ class Bucket {
    */
   async list(prefix, opts = {}) {
     const { shallow = false, maxItems = Number.POSITIVE_INFINITY } = opts;
-    const Prefix = sanitizeKey(prefix).replace(/^.+$/, '$&/');
+    const Prefix = sanitizePrefix(prefix);
 
     let ContinuationToken;
     const objects = [];
@@ -683,7 +696,7 @@ class Bucket {
    */
   async browse(prefix, opts = {}) {
     const { continuationToken, maxItems } = opts;
-    const Prefix = sanitizeKey(prefix).replace(/^.+$/, '$&/');
+    const Prefix = sanitizePrefix(prefix);
 
     const result = await this.client.send(new ListObjectsV2Command({
       Bucket: this.bucket,
@@ -735,17 +748,16 @@ class Bucket {
   async copyDeep(src, dst, filter = () => true, opts = {}) {
     const { log } = this;
     const tasks = [];
-    const Prefix = sanitizeKey(src);
     const dstRoot = sanitizeKey(dst);
-    this.log.info(`fetching list of files to copy ${this.bucket}/${Prefix} => ${dstRoot}`);
-    const { objects } = await this.list(Prefix);
+    this.log.info(`fetching list of files to copy ${this.bucket}/${src} => ${dstRoot}`);
+    const { prefix, objects } = await this.list(src);
     objects.forEach((obj) => {
       const { key, contentLength, contentType } = obj;
       if (filter(obj)) {
         // compute the path relative to Prefix; key starts with `Prefix/`
         // so key.substring(Prefix.length) has a leading `/` (or is empty
         // at the bucket root).  sanitizeKey strips that leading `/`.
-        const relPath = sanitizeKey(key.substring(Prefix.length));
+        const relPath = sanitizeKey(key.substring(prefix.length));
         tasks.push({
           src: key,
           contentLength,

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -723,7 +723,9 @@ class Bucket {
 
     return {
       objects: listResultToObjectInfos(result, root, includePrefixes),
-      continuationToken: result.IsTruncated ? result.NextContinuationToken : undefined,
+      continuationToken: result.IsTruncated
+        ? result.NextContinuationToken
+        : undefined,
     };
   }
 

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -774,6 +774,21 @@ class Bucket {
   }
 
   /**
+   * Convenience wrapper around {@link Bucket#list} that returns only the
+   * folder (common-prefix) paths directly below `prefix + path`. Always
+   * shallow.
+   *
+   * @param {string} prefix root of the subtree
+   * @param {string} [path] subdirectory within `prefix`. Defaults to `'/'`.
+   * @returns {Promise<string[]>} folder paths, each relative to `prefix`,
+   *  starting with `/`, never ending with `/`
+   */
+  async listFolders(prefix, path = '/') {
+    const { objects } = await this.list(prefix, path, { shallow: true });
+    return objects.filter((o) => o.isFolder).map((o) => o.path);
+  }
+
+  /**
    * Recursively copy the tree below `src` to `dst`. Lists every object under
    * `src`, applies `filter`, then issues per-object `CopyObject` commands with
    * concurrency 64. Errors on individual objects are logged but do not abort

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -110,33 +110,6 @@ function sanitizeKey(keyOrPath) {
 }
 
 /**
- * Normalize a directory-style path: ensures it starts *and* ends with `/`.
- * Used when building an S3 list prefix from a `prefix + path` pair where
- * `path` is always interpreted as a directory.
- *
- * @param {string} path
- * @returns {string}
- */
-function ensureDirPath(path) {
-  let p = path.charAt(0) === '/' ? path : `/${path}`;
-  if (p.charAt(p.length - 1) !== '/') {
-    p += '/';
-  }
-  return p;
-}
-
-/**
- * Strip a leading `/` if present. Used after concatenating a (possibly
- * empty) root with a leading-slashed path to produce a canonical S3 key.
- *
- * @param {string} s
- * @returns {string}
- */
-function stripLeadingSlash(s) {
-  return s.charAt(0) === '/' ? s.substring(1) : s;
-}
-
-/**
  * Returns the last segment of a key, treating an optional trailing `/` as a
  * folder separator. E.g. `/blog/2024/post.md` → `post.md`,
  * `/blog/2024/` → `2024`, `foo` → `foo`.
@@ -155,35 +128,18 @@ function basename(key) {
  * {@link Bucket#list} and {@link Bucket#browse}; the `Delimiter` setting on
  * the underlying request determines whether `CommonPrefixes` are present.
  *
- * The `path` field on each entry is computed by stripping `pathBase` from the
- * front of the entry's key. `pathBase` is `''` when the listing root is the
- * bucket root, otherwise `${root}/`. A leading `/` is then prepended so every
- * returned path starts with `/`, and any trailing `/` (for common prefixes)
- * is dropped — paths are uniform: start with `/`, never end with `/`. The
- * `isFolder` flag carries the file/folder distinction.
- *
  * @param {object} result the `ListObjectsV2Command` response
- * @param {string} pathBase prefix to strip from each entry's `key` to compute
- *  its `path` (empty string when the listing root is the bucket root)
  * @returns {ObjectInfo[]}
  */
-function listResultToObjectInfos(result, pathBase) {
-  const baseLen = pathBase.length;
+function listResultToObjectInfos(result) {
   const objects = [];
   (result.CommonPrefixes || []).forEach(({ Prefix }) => {
-    objects.push({
-      key: Prefix,
-      // S3 always returns CommonPrefix values ending with `/`; drop it.
-      path: `/${Prefix.substring(baseLen).replace(/\/$/, '')}`,
-      name: basename(Prefix),
-      isFolder: true,
-    });
+    objects.push({ key: Prefix, name: basename(Prefix), isFolder: true });
   });
   (result.Contents || []).forEach((content) => {
     const key = content.Key;
     objects.push({
       key,
-      path: `/${key.substring(baseLen)}`,
       name: basename(key),
       isFolder: false,
       lastModified: content.LastModified,
@@ -672,30 +628,21 @@ class Bucket {
   }
 
   /**
-   * List objects below `prefix + path`. Pages through `ListObjectsV2` until the
+   * List objects below `prefix`. Pages through `ListObjectsV2` until the
    * result is no longer truncated or `maxItems` is reached.
    *
-   * `prefix` is the fixed root of the subtree; `path` is the subdirectory
-   * within it (always interpreted as a directory: normalized to start *and*
-   * end with `/`). Each returned `ObjectInfo.path` is relative to `prefix`,
-   * starts with `/`, and never ends with `/` — the `isFolder` flag carries
-   * the file/folder distinction. When `shallow: true`, common prefixes
-   * (folders directly below the listed dir) are returned alongside files;
-   * callers filter by `isFolder` if they want only one kind.
+   * `prefix` is sanitized to canonical S3 form (no leading/trailing `/`).
+   * When `shallow: true`, common prefixes (folders directly below the prefix)
+   * are returned alongside files; callers filter by `isFolder` if they want
+   * only one kind.
    *
-   * @param {string} prefix root of the subtree to list under
-   * @param {string} [path] subdirectory within `prefix`. Defaults to `'/'`.
+   * @param {string} prefix key prefix to list under
    * @param {ListOptions} [opts]
    * @returns {Promise<ListResult>}
    */
-  async list(prefix, path = '/', opts = {}) {
+  async list(prefix, opts = {}) {
     const { shallow = false, maxItems = Number.POSITIVE_INFINITY } = opts;
-    const root = sanitizeKey(prefix);
-    const dir = ensureDirPath(path);
-    // strip any leading `/` from the concatenation: it only appears when
-    // `root` is empty (canonical S3 keys don't start with `/`).
-    const Prefix = stripLeadingSlash(`${root}${dir}`);
-    const pathBase = stripLeadingSlash(`${root}/`);
+    const Prefix = sanitizeKey(prefix).replace(/^.+$/, '$&/');
 
     let ContinuationToken;
     const objects = [];
@@ -712,50 +659,31 @@ class Bucket {
       // eslint-disable-next-line no-await-in-loop
       const result = await this.client.send(new ListObjectsV2Command(input));
       ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
-      objects.push(...listResultToObjectInfos(result, pathBase));
+      objects.push(...listResultToObjectInfos(result));
     } while (ContinuationToken && objects.length < maxItems);
-    return { objects, continuationToken: undefined };
+    return { prefix: Prefix, objects, continuationToken: undefined };
   }
 
   /**
    * Single-page, always-shallow listing intended for paginated UI browsing.
    *
-   * `prefix` is the fixed root (constant during navigation); `path` is the
-   * subdirectory within it (always interpreted as a directory: normalized
-   * to start *and* end with `/`). The actual S3 prefix sent is
-   * `prefix + path`. Each returned `ObjectInfo.path` is relative to
-   * `prefix`, starts with `/`, and never ends with `/`; the `isFolder` flag
-   * carries the file/folder distinction. The caller can pass an entry's
-   * `path` straight back as the next call's `path` argument to drill in
-   * without reconstructing breadcrumbs.
-   *
-   * Example:
-   *
-   * ```js
-   * const ROOT = 'owner/repo/main/';
-   * const r1 = await bus.browse(ROOT);
-   * // r1.objects[i].path -> '/blog', '/images', '/index.md', ...
-   * const r2 = await bus.browse(ROOT, r1.objects[0].path); // '/blog'
-   * // r2.objects[i].path -> '/blog/2024', '/blog/index.md', ...
-   * ```
+   * `prefix` is sanitized to canonical S3 form (no leading/trailing `/`).
+   * Common prefixes (folders) and files at the first level below `prefix`
+   * are returned; callers filter by `isFolder` if they want only one kind.
+   * The `isFolder` flag carries the file/folder distinction.
    *
    * Unlike {@link Bucket#list}, this does not auto-page: it issues one
-   * `ListObjectsV2` call, returns the entries it received, and exposes the
+   * `ListObjectsV2` call, returns the entries received, and exposes the
    * `NextContinuationToken` so the caller can request the next page on
    * demand. `maxItems` controls the page size only.
    *
-   * @param {string} prefix root of the subtree being browsed
-   * @param {string} [path] subdirectory within `prefix` to list. Defaults
-   *  to `'/'`.
+   * @param {string} prefix key prefix to browse (the directory to list)
    * @param {BrowseOptions} [opts]
    * @returns {Promise<ListResult>}
    */
-  async browse(prefix, path = '/', opts = {}) {
+  async browse(prefix, opts = {}) {
     const { continuationToken, maxItems } = opts;
-    const root = sanitizeKey(prefix);
-    const dir = ensureDirPath(path);
-    const Prefix = stripLeadingSlash(`${root}${dir}`);
-    const pathBase = stripLeadingSlash(`${root}/`);
+    const Prefix = sanitizeKey(prefix).replace(/^.+$/, '$&/');
 
     const result = await this.client.send(new ListObjectsV2Command({
       Bucket: this.bucket,
@@ -766,7 +694,8 @@ class Bucket {
     }));
 
     return {
-      objects: listResultToObjectInfos(result, pathBase),
+      prefix: Prefix,
+      objects: listResultToObjectInfos(result),
       continuationToken: result.IsTruncated
         ? result.NextContinuationToken
         : undefined,
@@ -775,19 +704,17 @@ class Bucket {
 
   /**
    * Convenience wrapper around {@link Bucket#list} that returns only the
-   * folder (common-prefix) paths directly below `prefix + path`. Always
-   * shallow.
+   * folder (common-prefix) basenames directly below `prefix`. Always shallow.
    *
-   * @param {string} prefix root of the subtree
-   * @param {string} [path] subdirectory within `prefix`. Defaults to `'/'`.
-   * @returns {Promise<string[]>} folder paths, each relative to `prefix`,
-   *  starting with `/`, never ending with `/`
+   * @param {string} prefix key prefix to list under
+   * @returns {Promise<string[]>} folder basenames (the {@link ObjectInfo.name}
+   *  of each folder entry)
    */
-  async listFolders(prefix, path = '/') {
-    const { objects } = await this.list(prefix, path, { shallow: true });
+  async listFolders(prefix) {
+    const { objects } = await this.list(prefix, { shallow: true });
     return objects
       .filter((o) => o.isFolder)
-      .map((o) => o.path);
+      .map((o) => o.name);
   }
 
   /**
@@ -801,7 +728,7 @@ class Bucket {
    * @param {ObjectFilter} [filter] filter function; only objects for which it
    *  returns truthy are copied
    * @param {CopyOptions} [opts]
-   * @returns {Promise<Array<{src: string, dst: string, path: string,
+   * @returns {Promise<Array<{src: string, dst: string,
    *  contentLength?: number, contentType?: string|null}>>}
    *  the list of tasks that were copied successfully
    */
@@ -809,26 +736,21 @@ class Bucket {
     const { log } = this;
     const tasks = [];
     const Prefix = sanitizeKey(src);
-    // dst is sanitized to canonical form (no leading/trailing `/`) so it
-    // can be concatenated with `path`, which is root-relative and always starts with `/`.
     const dstRoot = sanitizeKey(dst);
     this.log.info(`fetching list of files to copy ${this.bucket}/${Prefix} => ${dstRoot}`);
     const { objects } = await this.list(Prefix);
     objects.forEach((obj) => {
-      const {
-        path, key, contentLength, contentType,
-      } = obj;
+      const { key, contentLength, contentType } = obj;
       if (filter(obj)) {
+        // compute the path relative to Prefix; key starts with `Prefix/`
+        // so key.substring(Prefix.length) has a leading `/` (or is empty
+        // at the bucket root).  sanitizeKey strips that leading `/`.
+        const relPath = sanitizeKey(key.substring(Prefix.length));
         tasks.push({
           src: key,
-          path,
           contentLength,
           contentType,
-          // strip the leading `/` that `path` always carries; for non-empty
-          // `dstRoot` the leading `/` acts as the separator, for empty
-          // `dstRoot` (copying to the bucket root) we'd otherwise end up
-          // with a non-canonical S3 key.
-          dst: stripLeadingSlash(`${dstRoot}${path}`),
+          dst: dstRoot ? `${dstRoot}/${relPath}` : relPath,
         });
       }
     });

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -120,8 +120,9 @@ function basename(key) {
 /**
  * Normalize the `prefix` + `path` arguments shared by {@link Bucket#list}
  * and {@link Bucket#browse} into:
- * - `root`: `prefix` with any trailing `/` stripped — the strip-base for
- *   computing each entry's root-relative `path`.
+ * - `root`: `prefix` with any leading and trailing `/` stripped — the
+ *   strip-base for computing each entry's root-relative `path`. Stripped
+ *   to canonical S3 form (S3 keys don't start with `/`).
  * - `dir`: the path argument, always interpreted as a directory (starts
  *   with `/` and ends with `/`).
  *
@@ -132,7 +133,7 @@ function basename(key) {
  * @returns {{ root: string, dir: string }}
  */
 function normalizePrefixAndPath(prefix, path) {
-  const root = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  const root = sanitizeKey(prefix).replace(/\/$/, '');
   let dir = path.startsWith('/') ? path : `/${path}`;
   if (!dir.endsWith('/')) {
     dir += '/';

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -34,21 +34,33 @@ const gzip = promisify(zlib.gzip);
 const gunzip = promisify(zlib.gunzip);
 
 /**
- * Maximum number of objects to delete in one operation.
+ * Maximum number of keys that can be deleted in a single `DeleteObjects` call (S3 limit).
  */
 const MAX_DELETE_OBJECTS = 1000;
 
 /**
  * @typedef {import('@aws-sdk/client-s3').CommandInput} CommandInput
+ * @typedef {import('@aws-sdk/client-s3').HeadObjectCommandOutput} HeadObjectCommandOutput
+ * @typedef {import('@aws-sdk/client-s3').PutObjectCommandOutput} PutObjectCommandOutput
+ * @typedef {import('@aws-sdk/client-s3').CopyObjectCommandOutput} CopyObjectCommandOutput
+ * @typedef {import('@aws-sdk/client-s3').CopyObjectResult} CopyObjectResult
+ * @typedef {import('@aws-sdk/client-s3').DeleteObjectCommandOutput} DeleteObjectCommandOutput
  * @typedef {import('./storage.d').Bucket} BucketType
  * @typedef {import('./storage.d').HelixStorage} HelixStorageType
+ * @typedef {import('./storage.d').HelixStorageOptions} HelixStorageOptions
+ * @typedef {import('./storage.d').HelixStorageContext} HelixStorageContext
+ * @typedef {import('./storage.d').BucketMap} BucketMap
+ * @typedef {import('./storage.d').BulkDeleteResult} BulkDeleteResult
  * @typedef {import('./storage.d').ObjectInfo} ObjectInfo
  * @typedef {import('./storage.d').ObjectFilter} ObjectFilter
  * @typedef {import('./storage.d').CopyOptions} CopyOptions
+ * @typedef {import('./storage.d').ListOptions} ListOptions
  */
 
 /**
- * Header names that AWS considers system defined.
+ * Response header names treated as S3 system fields. When `store()` encounters one of
+ * these, it forwards the value to the corresponding `*Command` input property
+ * (e.g. `content-type` -> `ContentType`) rather than writing it as user metadata.
  */
 const AWS_S3_SYSTEM_HEADERS = [
   'cache-control',
@@ -57,7 +69,8 @@ const AWS_S3_SYSTEM_HEADERS = [
 ];
 
 /**
- * result object headers
+ * Fields on a `GetObject` response that are surfaced as metadata when the caller of
+ * {@link Bucket#get} provides a `meta` output object.
  */
 const AWS_META_HEADERS = [
   'CacheControl',
@@ -69,7 +82,8 @@ const AWS_META_HEADERS = [
 ];
 
 /**
- * Response header names that need a different metadata name.
+ * Response headers that need to be renamed before being written as user metadata,
+ * to avoid colliding with S3-controlled headers.
  */
 const METADATA_HEADER_MAP = new Map([
   ['last-modified', 'x-source-last-modified'],
@@ -89,6 +103,13 @@ function sanitizeKey(keyOrPath) {
 
 const BUCKET_KEYS = ['config', 'code', 'content', 'media', 'source'];
 
+/**
+ * Parses the `HELIX_BUCKET_NAMES` env var into a {@link BucketMap}. When `bucketNames`
+ * is falsy, returns the default `helix-<key>-bus` mapping for each well-known bus.
+ *
+ * @param {string} [bucketNames] JSON-encoded bus-key -> bucket-name map
+ * @returns {BucketMap}
+ */
 export function parseBucketNames(bucketNames) {
   if (!bucketNames) {
     return Object.fromEntries(BUCKET_KEYS.map((key) => [key, `helix-${key}-bus`]));
@@ -228,6 +249,15 @@ class Bucket {
     }
   }
 
+  /**
+   * Issue a HEAD on the object and return the raw S3 response.
+   *
+   * @param {string} path object key
+   * @param {object} [headOpts] extra fields merged into the `HeadObjectCommand` input
+   * @returns {Promise<HeadObjectCommandOutput|null>}
+   *  the HEAD response, or `null` when the key does not exist
+   * @throws an error if the object could not be loaded due to an unexpected error.
+   */
   async head(path, headOpts = {}) {
     const input = {
       ...headOpts,
@@ -260,10 +290,16 @@ class Bucket {
   }
 
   /**
-   * Internal helper for sending a command to both S3 and R2 clients.
-   * @param {function} CommandConstructor constructor of command to send to the client
+   * Internal helper that sends the same command to both S3 and R2 in parallel.
+   * The result of the primary (S3) call is returned. If only one client fails,
+   * the rejection from that client is rethrown with an `[S3]` or `[R2]` prefix
+   * on its message so the failing leg is identifiable.
+   *
+   * @param {function} CommandConstructor command class to instantiate
    * @param {CommandInput} input command input
-   * @returns {Promise<*>} the command result
+   * @param {string[]} [measures] when provided, populated with the per-client
+   *  latency in seconds (one entry per client, in `_clients` order)
+   * @returns {Promise<*>} the command result from the primary (S3) client
    */
   async sendToS3andR2(CommandConstructor, input, measures) {
     // send cmd to s3 and r2 (mirror) in parallel
@@ -292,11 +328,15 @@ class Bucket {
   }
 
   /**
-   * Store an object contents, along with headers.
+   * Store an object body and headers from a fetch `Response`. The body is gzipped
+   * (or passed through if the response already has `content-encoding: gzip`);
+   * response headers are translated into S3 system fields (for `cache-control`,
+   * `content-type`, `expires`) or written as user metadata. Mirrored to R2 when
+   * enabled.
    *
    * @param {string} key object key
-   * @param {Response} res response to store
-   * @returns result obtained from S3
+   * @param {Response} res response whose body and headers should be stored
+   * @returns {Promise<void>} resolves once both clients have completed; failures throw
    */
   async store(key, res) {
     const { log } = this;
@@ -331,14 +371,15 @@ class Bucket {
   }
 
   /**
-   * Store an object contents, along with metadata.
+   * Store an object's contents along with metadata. Mirrored to R2 when enabled.
    *
    * @param {string} path object key
    * @param {Buffer|string} body data to store
-   * @param {string} [contentType] content type. defaults to 'application/octet-stream'
-   * @param {object} [meta] metadata to store with the object. defaults to '{}'
-   * @param {boolean} [compress = true]
-   * @returns result obtained from S3
+   * @param {string} [contentType] content type. Defaults to `application/octet-stream`.
+   * @param {Record<string, string>} [meta] metadata to store with the object. Defaults to `{}`.
+   * @param {boolean} [compress] whether to gzip the body and set
+   *  `ContentEncoding: gzip`. Defaults to `true`.
+   * @returns {Promise<PutObjectCommandOutput>} result of the primary S3 PutObject call
    */
   async put(path, body, contentType = 'application/octet-stream', meta = {}, compress = true) {
     const input = {
@@ -360,11 +401,13 @@ class Bucket {
   }
 
   /**
-   * Updates the metadata
-   * @param {string} path
-   * @param {object} meta
-   * @param {object} opts
-   * @returns {Promise<*>}
+   * Replace an object's user metadata via a self-copy with `MetadataDirective: REPLACE`.
+   * Mirrored to R2 when enabled.
+   *
+   * @param {string} path object key
+   * @param {Record<string, string>} meta new metadata (fully replaces existing metadata)
+   * @param {object} [opts] extra fields merged into the underlying `CopyObjectCommand` input
+   * @returns {Promise<CopyObjectCommandOutput>}
    */
   async putMeta(path, meta, opts = {}) {
     const key = sanitizeKey(path);
@@ -385,12 +428,18 @@ class Bucket {
   }
 
   /**
-   * Copy an object in the same bucket.
+   * Copy an object within the same bucket. When `addMetadata` or `renameMetadata`
+   * are provided, the source's HEAD is consulted so that selected system headers
+   * (`ContentType`, `ContentEncoding`, `CacheControl`, `ContentDisposition`,
+   * `Expires`) are preserved and metadata is rewritten with
+   * `MetadataDirective: REPLACE`. Mirrored to R2 when enabled.
    *
    * @param {string} src source key
    * @param {string} dst destination key
    * @param {CopyOptions} [opts]
-   * @returns result obtained from S3
+   * @returns {Promise<CopyObjectResult|undefined>} the `CopyObjectResult` from the
+   *  primary S3 call (S3 may omit it under some conditions)
+   * @throws an error with `status: 404` if the source object does not exist
    */
   async copy(src, dst, opts = {}) {
     const key = sanitizeKey(src);
@@ -439,12 +488,25 @@ class Bucket {
   }
 
   /**
-   * Remove object(s)
+   * Remove one or more objects. Mirrored to R2 when enabled.
    *
-   * @param {string|string[]} path source key(s)
-   * @param {string} [sourceInfo] informational message of the source
-   * @param {boolean} [stopOnError]
-   * @returns result obtained from S3
+   * When passed an array, the input is sliced into chunks of up to
+   * {@link MAX_DELETE_OBJECTS} keys (the S3 limit) and the chunks are processed
+   * in parallel (concurrency 2). Errors per chunk are accumulated into the
+   * returned `Errors` array unless `stopOnError` is set, in which case the first
+   * failing chunk throws.
+   *
+   * When passed a single key string, a `DeleteObject` command is sent and any
+   * failure is rethrown as an error with `status` set to the HTTP status code.
+   *
+   * @param {string|string[]} path single key, or array of keys
+   * @param {string} [sourceInfo] informational message used in log output
+   *  (only relevant for the array form)
+   * @param {boolean} [stopOnError] when `true` and `path` is an array, throw on
+   *  the first chunk that fails instead of collecting errors
+   * @returns {Promise<DeleteObjectCommandOutput|BulkDeleteResult>}
+   *  the raw `DeleteObject` response for a single key, or an aggregated
+   *  `{ Deleted, Errors }` object for an array of keys
    */
   async remove(path, sourceInfo = '', stopOnError = false) {
     const { log, bucket } = this;
@@ -517,11 +579,12 @@ class Bucket {
   }
 
   /**
-   * Returns a list of object below the given prefix.
+   * List objects below `prefix`. Pages through `ListObjectsV2` until the result
+   * is no longer truncated or `maxItems` is reached.
    *
-   * @param {string} prefix
-   * @param {boolean|import('./storage.d').ListOptions} [opts]
-   *  options or boolean for backward compatibility
+   * @param {string} prefix the key prefix to list under
+   * @param {boolean|ListOptions} [opts] list options. As a backward-compatibility
+   *  shortcut, passing `true` is equivalent to `{ shallow: true }`.
    * @returns {Promise<ObjectInfo[]>}
    */
   async list(prefix, opts = false) {
@@ -568,6 +631,14 @@ class Bucket {
     return objects;
   }
 
+  /**
+   * List the common prefixes (subfolders) directly below `prefix`. Equivalent
+   * to a `ListObjectsV2` with `Delimiter: '/'`, returning only the
+   * `CommonPrefixes` aggregated across pages.
+   *
+   * @param {string} prefix
+   * @returns {Promise<string[]>} the list of common prefixes (each ending with `/`)
+   */
   async listFolders(prefix) {
     let ContinuationToken;
     const folders = [];
@@ -588,12 +659,19 @@ class Bucket {
   }
 
   /**
-   * Copies the tree below src to dst.
-   * @param {string} src Source prefix
-   * @param {string} dst Destination prefix
-   * @param {ObjectFilter} filter Filter function
-   * @param {CopyOptions} [opts={}]
-   * @returns {Promise<*[]>}
+   * Recursively copy the tree below `src` to `dst`. Lists every object under
+   * `src`, applies `filter`, then issues per-object `CopyObject` commands with
+   * concurrency 64. Errors on individual objects are logged but do not abort
+   * the operation.
+   *
+   * @param {string} src source prefix
+   * @param {string} dst destination prefix
+   * @param {ObjectFilter} [filter] filter function; only objects for which it
+   *  returns truthy are copied
+   * @param {CopyOptions} [opts]
+   * @returns {Promise<Array<{src: string, dst: string, path: string,
+   *  contentLength?: number, contentType?: string|null}>>}
+   *  the list of tasks that were copied successfully
    */
   async copyDeep(src, dst, filter = () => true, opts = {}) {
     const { log } = this;
@@ -658,6 +736,13 @@ class Bucket {
     return changes;
   }
 
+  /**
+   * Recursively delete every object below `src`. Equivalent to listing the
+   * prefix and then bulk-deleting all returned keys.
+   *
+   * @param {string} src key prefix
+   * @returns {Promise<BulkDeleteResult>}
+   */
   async rmdir(src) {
     src = sanitizeKey(src);
     this.log.info(`fetching list of files to delete from ${this.bucket}/${src}`);
@@ -671,6 +756,16 @@ class Bucket {
  * @implements {HelixStorageType}
  */
 export class HelixStorage {
+  /**
+   * Get (and lazily construct + cache) a {@link HelixStorage} for a Helix function
+   * `context`. Reads configuration from `context.env` (region, credentials, R2
+   * settings, timeouts, bucket-name overrides) and caches the resulting instance
+   * on `context.attributes.storage` so repeat calls within the same invocation
+   * share clients.
+   *
+   * @param {HelixStorageContext} context
+   * @returns {HelixStorage}
+   */
   static fromContext(context) {
     if (!context.attributes.storage) {
       const {
@@ -709,17 +804,11 @@ export class HelixStorage {
   };
 
   /**
-   * Create an instance
+   * Create a storage instance. Constructs an S3 client (using explicit credentials
+   * if provided, otherwise the SDK default credential chain) and an R2 client
+   * unless `disableR2` is `true`.
    *
-   * @param {object} [opts] options
-   * @param {string} [opts.region] AWS region
-   * @param {string} [opts.accessKeyId] AWS access key
-   * @param {string} [opts.secretAccessKey] AWS secret access key
-   * @param {string} [opts.r2AccountId]
-   * @param {string} [opts.r2AccessKeyId]
-   * @param {string} [opts.r2SecretAccessKey]
-   * @param {object} [opts.log] logger
-   * @param {string} [opts.maxAttempts] max attempts or Number.NaN
+   * @param {HelixStorageOptions} [opts]
    */
   constructor(opts = {}) {
     const {
@@ -785,15 +874,22 @@ export class HelixStorage {
     this._log = log;
   }
 
+  /**
+   * @returns {S3Client} the underlying primary S3 client
+   */
   s3() {
     return this._s3;
   }
 
   /**
-   * creates a bucket instance that allows to perform storage related operations.
-   * @param bucketId
-   * @param disableR2 whether to disable R2 for storing
+   * Create a {@link Bucket} for the given bucket id. The returned bucket reuses
+   * the storage's S3 client (and R2 client unless `disableR2` is `true`).
+   *
+   * @param {string} bucketId bucket name
+   * @param {boolean} [disableR2] when `true`, this bucket will not mirror writes
+   *  to R2 even if R2 is otherwise configured
    * @returns {Bucket}
+   * @throws if the storage has been closed or if `bucketId` is empty
    */
   bucket(bucketId, disableR2 = false) {
     if (!this._s3) {
@@ -811,6 +907,9 @@ export class HelixStorage {
   }
 
   /**
+   * Bucket for the configured `content` bus.
+   *
+   * @param {boolean} [disableR2]
    * @returns {Bucket}
    */
   contentBus(disableR2 = false) {
@@ -818,6 +917,9 @@ export class HelixStorage {
   }
 
   /**
+   * Bucket for the configured `code` bus.
+   *
+   * @param {boolean} [disableR2]
    * @returns {Bucket}
    */
   codeBus(disableR2 = false) {
@@ -825,6 +927,8 @@ export class HelixStorage {
   }
 
   /**
+   * Bucket for the configured `media` bus. R2 mirroring is always disabled here.
+   *
    * @returns {Bucket}
    */
   mediaBus() {
@@ -832,6 +936,10 @@ export class HelixStorage {
   }
 
   /**
+   * Bucket for the configured `source` bus. R2 mirroring defaults to disabled
+   * since the source bus is typically not mirrored.
+   *
+   * @param {boolean} [disableR2]
    * @returns {Bucket}
    */
   sourceBus(disableR2 = true) {
@@ -839,6 +947,8 @@ export class HelixStorage {
   }
 
   /**
+   * Bucket for the configured `config` bus. R2 mirroring is always disabled here.
+   *
    * @returns {Bucket}
    */
   configBus() {
@@ -846,7 +956,9 @@ export class HelixStorage {
   }
 
   /**
-   * Close this storage. Destroys the S3 client used.
+   * Close this storage. Destroys the underlying S3 (and R2) clients and renders
+   * this instance unusable; subsequent calls to {@link HelixStorage#bucket}
+   * throw.
    */
   close() {
     this._s3?.destroy();

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -611,7 +611,7 @@ class Bucket {
           errors += chunk.length;
           if (stopOnError) {
             const msg = `removing ${input.Delete.Objects.length} objects from bucket ${input.Bucket} failed: ${e.message}`;
-            this.log.error(msg);
+            log.error(msg);
             const e2 = new Error(msg);
             e2.status = e.$metadata.httpStatusCode;
             throw e2;
@@ -749,8 +749,10 @@ class Bucket {
     const { log } = this;
     const tasks = [];
     const dstRoot = sanitizeKey(dst);
-    this.log.info(`fetching list of files to copy ${this.bucket}/${src} => ${dstRoot}`);
-    const { prefix, objects } = await this.list(src);
+    const prefix = sanitizePrefix(src);
+    log.info(`fetching list of files to copy ${this.bucket}/${prefix} => ${dstRoot}`);
+
+    const { objects } = await this.list(src);
     objects.forEach((obj) => {
       const { key, contentLength, contentType } = obj;
       if (filter(obj)) {

--- a/packages/helix-shared-storage/test/fixtures/list-deep-reply.json
+++ b/packages/helix-shared-storage/test/fixtures/list-deep-reply.json
@@ -8,15 +8,15 @@
     "Delimiter": "/",
     "IsTruncated": false,
     "Contents": [{
-      "Key": "/owner/repo/ref/.gitignore",
+      "Key": "owner/repo/ref/.gitignore",
       "LastModified": "2021-05-05T08:00:30.000Z",
       "Size": "11"
     }, {
-      "Key": "/owner/repo/ref/README.md",
+      "Key": "owner/repo/ref/README.md",
       "LastModified": "2021-05-05T08:00:30.000Z",
       "Size": "1234"
     }, {
-      "Key": "/owner/repo/ref/src/scripts.js",
+      "Key": "owner/repo/ref/src/scripts.js",
       "LastModified": "2021-05-05T08:00:30.000Z",
       "Size": "1234"
     }]

--- a/packages/helix-shared-storage/test/fixtures/list-folders-reply.json
+++ b/packages/helix-shared-storage/test/fixtures/list-folders-reply.json
@@ -2,27 +2,27 @@
   {
     "ListBucketResult": {
       "Name": "helix-code-bus",
-      "Prefix": "",
+      "Prefix": "foo/",
       "NextContinuationToken": "next",
       "KeyCount": 1,
       "MaxKeys": 1,
       "Delimiter": "/",
       "IsTruncated": true,
       "CommonPrefixes": [{
-        "Prefix": "owner/"
+        "Prefix": "foo/owner/"
       }]
     }
   },
   {
     "ListBucketResult": {
       "Name": "helix-code-bus",
-      "Prefix": "",
+      "Prefix": "foo/",
       "KeyCount": 1,
       "MaxKeys": 1,
       "Delimiter": "/",
       "IsTruncated": false,
       "CommonPrefixes": [{
-        "Prefix": "other/"
+        "Prefix": "foo/other/"
       }]
     }
   }

--- a/packages/helix-shared-storage/test/fixtures/list-shallow-reply.json
+++ b/packages/helix-shared-storage/test/fixtures/list-shallow-reply.json
@@ -8,11 +8,11 @@
     "Delimiter": "/",
     "IsTruncated": false,
     "Contents": [{
-      "Key": "/owner/repo/ref/.gitignore",
+      "Key": "owner/repo/ref/.gitignore",
       "LastModified": "2021-05-05T08:00:30.000Z",
       "Size": "11"
     }, {
-      "Key": "/owner/repo/ref/README.md",
+      "Key": "owner/repo/ref/README.md",
       "LastModified": "2021-05-05T08:00:30.000Z",
       "Size": "1234"
     }]

--- a/packages/helix-shared-storage/test/fixtures/list-subfolder-prefixes.json
+++ b/packages/helix-shared-storage/test/fixtures/list-subfolder-prefixes.json
@@ -8,14 +8,14 @@
     "Delimiter": "/",
     "IsTruncated": false,
     "Contents": [{
-      "Key": "/owner/repo/ref/myfolder/somefile.html",
+      "Key": "owner/repo/ref/myfolder/somefile.html",
       "LastModified": "2021-06-06T04:05:06.000Z",
       "Size": "999999"
     }],
     "CommonPrefixes": [{
-      "Prefix": "/owner/repo/ref/myfolder/sub1/"
+      "Prefix": "owner/repo/ref/myfolder/sub1/"
     }, {
-      "Prefix": "/owner/repo/ref/myfolder/sub2/"
+      "Prefix": "owner/repo/ref/myfolder/sub2/"
     }]
   }
 }

--- a/packages/helix-shared-storage/test/fixtures/list-truncated-reply.json
+++ b/packages/helix-shared-storage/test/fixtures/list-truncated-reply.json
@@ -8,11 +8,11 @@
     "Delimiter": "/",
     "IsTruncated": true,
     "Contents": [{
-      "Key": "/owner/repo/ref/.gitignore",
+      "Key": "owner/repo/ref/.gitignore",
       "LastModified": "2021-05-05T08:00:30.000Z",
       "Size": "11"
     }, {
-      "Key": "/owner/repo/ref/README.md",
+      "Key": "owner/repo/ref/README.md",
       "LastModified": "2021-05-05T08:00:30.000Z",
       "Size": "1234"
     }]

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1189,7 +1189,7 @@ describe('Storage test', () => {
   it('can list shallow', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-shallow-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=%2Fowner%2Frepo%2Fref%2F')
+      .get('/?delimiter=%2F&list-type=2&prefix=owner%2Frepo%2Fref%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1200,7 +1200,7 @@ describe('Storage test', () => {
         {
           contentLength: 11,
           contentType: null,
-          key: '/owner/repo/ref/.gitignore',
+          key: 'owner/repo/ref/.gitignore',
           lastModified: new Date('2021-05-05T08:00:30.000Z'),
           path: '/.gitignore',
           name: '.gitignore',
@@ -1209,7 +1209,7 @@ describe('Storage test', () => {
         {
           contentLength: 1234,
           contentType: 'text/markdown',
-          key: '/owner/repo/ref/README.md',
+          key: 'owner/repo/ref/README.md',
           lastModified: new Date('2021-05-05T08:00:30.000Z'),
           path: '/README.md',
           name: 'README.md',
@@ -1223,7 +1223,7 @@ describe('Storage test', () => {
   it('can list deep', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-deep-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=%2Fowner%2Frepo%2Fref%2F')
+      .get('/?list-type=2&prefix=owner%2Frepo%2Fref%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1233,7 +1233,7 @@ describe('Storage test', () => {
       {
         contentLength: 11,
         contentType: null,
-        key: '/owner/repo/ref/.gitignore',
+        key: 'owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/.gitignore',
         name: '.gitignore',
@@ -1242,7 +1242,7 @@ describe('Storage test', () => {
       {
         contentLength: 1234,
         contentType: 'text/markdown',
-        key: '/owner/repo/ref/README.md',
+        key: 'owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/README.md',
         name: 'README.md',
@@ -1251,7 +1251,7 @@ describe('Storage test', () => {
       {
         contentLength: 1234,
         contentType: 'text/javascript',
-        key: '/owner/repo/ref/src/scripts.js',
+        key: 'owner/repo/ref/src/scripts.js',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/src/scripts.js',
         name: 'scripts.js',
@@ -1263,7 +1263,7 @@ describe('Storage test', () => {
   it('shallow list returns mixed files and folders', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
+      .get('/?delimiter=%2F&list-type=2&prefix=owner%2Frepo%2Fref%2Fmyfolder%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1271,13 +1271,13 @@ describe('Storage test', () => {
 
     assert.deepStrictEqual(result.objects, [
       {
-        key: '/owner/repo/ref/myfolder/sub1/',
+        key: 'owner/repo/ref/myfolder/sub1/',
         path: '/myfolder/sub1',
         name: 'sub1',
         isFolder: true,
       },
       {
-        key: '/owner/repo/ref/myfolder/sub2/',
+        key: 'owner/repo/ref/myfolder/sub2/',
         path: '/myfolder/sub2',
         name: 'sub2',
         isFolder: true,
@@ -1285,7 +1285,7 @@ describe('Storage test', () => {
       {
         contentLength: 999999,
         contentType: 'text/html',
-        key: '/owner/repo/ref/myfolder/somefile.html',
+        key: 'owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
         path: '/myfolder/somefile.html',
         name: 'somefile.html',
@@ -1298,7 +1298,7 @@ describe('Storage test', () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-truncated-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/')
-      .query({ 'list-type': 2, 'max-keys': 2, prefix: '/owner/repo/ref/' })
+      .query({ 'list-type': 2, 'max-keys': 2, prefix: 'owner/repo/ref/' })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1308,7 +1308,7 @@ describe('Storage test', () => {
       {
         contentLength: 11,
         contentType: null,
-        key: '/owner/repo/ref/.gitignore',
+        key: 'owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/.gitignore',
         name: '.gitignore',
@@ -1317,7 +1317,7 @@ describe('Storage test', () => {
       {
         contentLength: 1234,
         contentType: 'text/markdown',
-        key: '/owner/repo/ref/README.md',
+        key: 'owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/README.md',
         name: 'README.md',
@@ -1331,7 +1331,7 @@ describe('Storage test', () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/')
       .query({
-        'list-type': 2, delimiter: '/', 'max-keys': 2, prefix: '/owner/repo/ref/',
+        'list-type': 2, delimiter: '/', 'max-keys': 2, prefix: 'owner/repo/ref/',
       })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
@@ -1343,7 +1343,7 @@ describe('Storage test', () => {
       {
         contentLength: 11,
         contentType: null,
-        key: '/owner/repo/ref/.gitignore',
+        key: 'owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/.gitignore',
         name: '.gitignore',
@@ -1352,7 +1352,7 @@ describe('Storage test', () => {
       {
         contentLength: 1234,
         contentType: 'text/markdown',
-        key: '/owner/repo/ref/README.md',
+        key: 'owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/README.md',
         name: 'README.md',
@@ -1364,7 +1364,7 @@ describe('Storage test', () => {
   it('browse navigates a sub-path with root-relative result paths and normalizes path', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
+      .get('/?delimiter=%2F&list-type=2&prefix=owner%2Frepo%2Fref%2Fmyfolder%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1373,15 +1373,15 @@ describe('Storage test', () => {
 
     assert.deepStrictEqual(result.objects, [
       {
-        key: '/owner/repo/ref/myfolder/sub1/', path: '/myfolder/sub1', name: 'sub1', isFolder: true,
+        key: 'owner/repo/ref/myfolder/sub1/', path: '/myfolder/sub1', name: 'sub1', isFolder: true,
       },
       {
-        key: '/owner/repo/ref/myfolder/sub2/', path: '/myfolder/sub2', name: 'sub2', isFolder: true,
+        key: 'owner/repo/ref/myfolder/sub2/', path: '/myfolder/sub2', name: 'sub2', isFolder: true,
       },
       {
         contentLength: 999999,
         contentType: 'text/html',
-        key: '/owner/repo/ref/myfolder/somefile.html',
+        key: 'owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
         path: '/myfolder/somefile.html',
         name: 'somefile.html',
@@ -1395,7 +1395,7 @@ describe('Storage test', () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/')
       .query({
-        'list-type': 2, delimiter: '/', 'continuation-token': 'tok-1', prefix: '/owner/repo/ref/myfolder/',
+        'list-type': 2, delimiter: '/', 'continuation-token': 'tok-1', prefix: 'owner/repo/ref/myfolder/',
       })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -637,9 +637,10 @@ describe('Storage test', () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-reply-copy.json'), 'utf-8'));
     const puts = { s3: [], r2: [] };
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=owner%2Frepo%2Fref%2F')
+      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/ref/' })
       .reply(200, listReply[0])
-      .get('/?continuation-token=1%2Fs4dr7BSKNScrN4njX9%2BCpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE%2FICI8TxG%2BVNV9Hh91Ou0hqeBYzqTRzSBSs%3D&list-type=2&prefix=owner%2Frepo%2Fref%2F')
+      .get('/')
+      .query({ 'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=', 'list-type': 2, prefix: 'owner/repo/ref/' })
       .reply(200, listReply[1])
       .put(/.*/)
       .times(10)
@@ -688,9 +689,10 @@ describe('Storage test', () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-reply-copy.json'), 'utf-8'));
     const puts = { s3: [], r2: [] };
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=owner%2Frepo%2Fref%2F')
+      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/ref/' })
       .reply(200, listReply[0])
-      .get('/?continuation-token=1%2Fs4dr7BSKNScrN4njX9%2BCpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE%2FICI8TxG%2BVNV9Hh91Ou0hqeBYzqTRzSBSs%3D&list-type=2&prefix=owner%2Frepo%2Fref%2F')
+      .get('/')
+      .query({ 'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=', 'list-type': 2, prefix: 'owner/repo/ref/' })
       .reply(200, listReply[1])
       .put(/.*/)
       .matchHeader('x-amz-copy-source-if-match', 'abc')
@@ -730,9 +732,10 @@ describe('Storage test', () => {
     const putsHeaders = { s3: [], r2: [] };
     const heads = [];
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=owner%2Frepo%2Fref%2F')
+      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/ref/' })
       .reply(200, listReply[0])
-      .get('/?continuation-token=1%2Fs4dr7BSKNScrN4njX9%2BCpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE%2FICI8TxG%2BVNV9Hh91Ou0hqeBYzqTRzSBSs%3D&list-type=2&prefix=owner%2Frepo%2Fref%2F')
+      .get('/')
+      .query({ 'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=', 'list-type': 2, prefix: 'owner/repo/ref/' })
       .reply(200, listReply[1])
       .head(/.*/)
       .times(10)
@@ -1106,7 +1109,7 @@ describe('Storage test', () => {
     });
     const deletes = { s3: [], r2: [] };
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=owner%2Frepo%2Fnew-branch%2F')
+      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/new-branch/' })
       .reply(200, listReply)
       .post('/?delete=')
       .twice()
@@ -1141,7 +1144,7 @@ describe('Storage test', () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-reply.json'), 'utf-8'));
 
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=owner%2Frepo%2Fnew-branch%2F')
+      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/new-branch/' })
       .reply(200, listReply.response)
       .post('/?delete=')
       .reply(404);
@@ -1155,7 +1158,7 @@ describe('Storage test', () => {
 
   it('rmdir works for empty dir', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=owner%2Frepo%2Fnew-branch%2F')
+      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/new-branch/' })
       .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>helix-code-bus</Name><Prefix>owner/repo/new-branch/</Prefix><KeyCount>0</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>');
 
     const bus = storage.codeBus();
@@ -1164,7 +1167,7 @@ describe('Storage test', () => {
 
   it('list with empty prefix uses canonical S3 form (no leading slash)', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=foo%2F')
+      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'foo/' })
       .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>helix-code-bus</Name>
@@ -1204,9 +1207,12 @@ describe('Storage test', () => {
   it('listFolders returns just the folder paths', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=foo%2F')
+      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'foo/' })
       .reply(200, new xml2js.Builder().buildObject(listReply[0]))
-      .get('/?continuation-token=next&delimiter=%2F&list-type=2&prefix=foo%2F')
+      .get('/')
+      .query({
+        'continuation-token': 'next', delimiter: '/', 'list-type': 2, prefix: 'foo/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply[1]));
 
     const bus = storage.codeBus();
@@ -1218,9 +1224,12 @@ describe('Storage test', () => {
   it('can list shallow across multiple pages', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=foo%2F')
+      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'foo/' })
       .reply(200, new xml2js.Builder().buildObject(listReply[0]))
-      .get('/?continuation-token=next&delimiter=%2F&list-type=2&prefix=foo%2F')
+      .get('/')
+      .query({
+        'continuation-token': 'next', delimiter: '/', 'list-type': 2, prefix: 'foo/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply[1]));
 
     const bus = storage.codeBus();
@@ -1243,7 +1252,7 @@ describe('Storage test', () => {
   it('can list shallow', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-shallow-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=owner%2Frepo%2Fref%2F')
+      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'owner/repo/ref/' })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1276,7 +1285,7 @@ describe('Storage test', () => {
   it('can list deep', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-deep-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=owner%2Frepo%2Fref%2F')
+      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/ref/' })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1313,7 +1322,7 @@ describe('Storage test', () => {
   it('shallow list returns mixed files and folders', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=owner%2Frepo%2Fref%2Fmyfolder%2F')
+      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'owner/repo/ref/myfolder/' })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1407,7 +1416,7 @@ describe('Storage test', () => {
   it('browse navigates a sub-path', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=owner%2Frepo%2Fref%2Fmyfolder%2F')
+      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'owner/repo/ref/myfolder/' })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1449,7 +1458,7 @@ describe('Storage test', () => {
 
   it('browse can return an empty page', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=empty%2F')
+      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'empty/' })
       .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <KeyCount>0</KeyCount>
@@ -1464,7 +1473,7 @@ describe('Storage test', () => {
 
   it('copyDeep with empty dst places files at bucket root', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=src%2F')
+      .get('/').query({ 'list-type': 2, prefix: 'src/' })
       .reply(200, '<?xml version="1.0" encoding="UTF-8"?>'
         + '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
         + '<IsTruncated>false</IsTruncated>'

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1192,6 +1192,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '.gitignore',
+        name: '.gitignore',
       },
       {
         contentLength: 1234,
@@ -1199,6 +1200,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: 'README.md',
+        name: 'README.md',
       },
     ]);
   });
@@ -1219,6 +1221,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '.gitignore',
+        name: '.gitignore',
       },
       {
         contentLength: 1234,
@@ -1226,6 +1229,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: 'README.md',
+        name: 'README.md',
       },
       {
         contentLength: 1234,
@@ -1233,6 +1237,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/src/scripts.js',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: 'src/scripts.js',
+        name: 'scripts.js',
       },
     ]);
   });
@@ -1250,10 +1255,12 @@ describe('Storage test', () => {
       {
         key: '/owner/repo/ref/myfolder/sub1/',
         path: 'sub1/',
+        name: 'sub1',
       },
       {
         key: '/owner/repo/ref/myfolder/sub2/',
         path: 'sub2/',
+        name: 'sub2',
       },
       {
         contentLength: 999999,
@@ -1261,6 +1268,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
         path: 'somefile.html',
+        name: 'somefile.html',
       },
     ]);
   });
@@ -1281,6 +1289,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
         path: 'somefile.html',
+        name: 'somefile.html',
       },
     ]);
   });
@@ -1305,6 +1314,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '.gitignore',
+        name: '.gitignore',
       },
       {
         contentLength: 1234,
@@ -1312,6 +1322,7 @@ describe('Storage test', () => {
         key: '/owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: 'README.md',
+        name: 'README.md',
       },
     ]);
   });
@@ -1326,7 +1337,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.browse('/owner/repo/ref/', { maxItems: 2 });
+    const result = await bus.browse('/owner/repo/ref/', '/', { maxItems: 2 });
 
     assert.strictEqual(result.continuationToken, 'next');
     assert.deepStrictEqual(result.objects, [
@@ -1335,14 +1346,40 @@ describe('Storage test', () => {
         contentType: null,
         key: '/owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '.gitignore',
+        path: '/.gitignore',
+        name: '.gitignore',
       },
       {
         contentLength: 1234,
         contentType: 'text/markdown',
         key: '/owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: 'README.md',
+        path: '/README.md',
+        name: 'README.md',
+      },
+    ]);
+  });
+
+  it('browse navigates a sub-path with root-relative result paths', async () => {
+    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/?delimiter=%2F&list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
+      .reply(200, new xml2js.Builder().buildObject(listReply));
+
+    const bus = storage.codeBus();
+    // path is normalized: 'myfolder/' becomes '/myfolder/'
+    const result = await bus.browse('/owner/repo/ref/', 'myfolder/');
+
+    assert.deepStrictEqual(result.objects, [
+      { key: '/owner/repo/ref/myfolder/sub1/', path: '/myfolder/sub1/', name: 'sub1' },
+      { key: '/owner/repo/ref/myfolder/sub2/', path: '/myfolder/sub2/', name: 'sub2' },
+      {
+        contentLength: 999999,
+        contentType: 'text/html',
+        key: '/owner/repo/ref/myfolder/somefile.html',
+        lastModified: new Date('2021-06-06T04:05:06.000Z'),
+        path: '/myfolder/somefile.html',
+        name: 'somefile.html',
       },
     ]);
   });
@@ -1357,18 +1394,19 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.browse('/owner/repo/ref/myfolder/', { continuationToken: 'tok-1' });
+    const result = await bus.browse('/owner/repo/ref/', '/myfolder/', { continuationToken: 'tok-1' });
 
     assert.strictEqual(result.continuationToken, undefined);
     assert.deepStrictEqual(result.objects, [
-      { key: '/owner/repo/ref/myfolder/sub1/', path: 'sub1/' },
-      { key: '/owner/repo/ref/myfolder/sub2/', path: 'sub2/' },
+      { key: '/owner/repo/ref/myfolder/sub1/', path: '/myfolder/sub1/', name: 'sub1' },
+      { key: '/owner/repo/ref/myfolder/sub2/', path: '/myfolder/sub2/', name: 'sub2' },
       {
         contentLength: 999999,
         contentType: 'text/html',
         key: '/owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
-        path: 'somefile.html',
+        path: '/myfolder/somefile.html',
+        name: 'somefile.html',
       },
     ]);
   });
@@ -1383,7 +1421,7 @@ describe('Storage test', () => {
 `);
 
     const bus = storage.codeBus();
-    const result = await bus.browse('empty/');
+    const result = await bus.browse('empty');
 
     assert.deepStrictEqual(result, { objects: [], continuationToken: undefined });
   });
@@ -1395,7 +1433,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.browse('/owner/repo/ref/myfolder/', { includePrefixes: false });
+    const result = await bus.browse('/owner/repo/ref/', '/myfolder/', { includePrefixes: false });
 
     assert.deepStrictEqual(result.objects, [
       {
@@ -1403,7 +1441,8 @@ describe('Storage test', () => {
         contentType: 'text/html',
         key: '/owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
-        path: 'somefile.html',
+        path: '/myfolder/somefile.html',
+        name: 'somefile.html',
       },
     ]);
   });

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1562,6 +1562,26 @@ describe('Storage test', () => {
     assert.deepStrictEqual(result, { prefix: 'empty/', objects: [], continuationToken: undefined });
   });
 
+  it('browse with empty prefix lists the entire bucket', async () => {
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': 2,
+        prefix: '',
+      })
+      .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <KeyCount>0</KeyCount>
+</ListBucketResult>
+`);
+
+    const bus = storage.codeBus();
+    const result = await bus.browse('');
+
+    assert.deepStrictEqual(result, { prefix: '', objects: [], continuationToken: undefined });
+  });
+
   it('copyDeep with empty dst places files at bucket root', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/')

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1202,6 +1202,20 @@ describe('Storage test', () => {
     ]);
   });
 
+  it('listFolders returns just the folder paths', async () => {
+    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/?delimiter=%2F&list-type=2&prefix=foo%2F')
+      .reply(200, new xml2js.Builder().buildObject(listReply[0]))
+      .get('/?continuation-token=next&delimiter=%2F&list-type=2&prefix=foo%2F')
+      .reply(200, new xml2js.Builder().buildObject(listReply[1]));
+
+    const bus = storage.codeBus();
+    const folders = await bus.listFolders('foo');
+
+    assert.deepStrictEqual(folders, ['/owner', '/other']);
+  });
+
   it('can list shallow across multiple pages', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -637,10 +637,18 @@ describe('Storage test', () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-reply-copy.json'), 'utf-8'));
     const puts = { s3: [], r2: [] };
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/ref/' })
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, listReply[0])
       .get('/')
-      .query({ 'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=', 'list-type': 2, prefix: 'owner/repo/ref/' })
+      .query({
+        'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=',
+        'list-type': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, listReply[1])
       .put(/.*/)
       .times(10)
@@ -689,10 +697,18 @@ describe('Storage test', () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-reply-copy.json'), 'utf-8'));
     const puts = { s3: [], r2: [] };
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/ref/' })
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, listReply[0])
       .get('/')
-      .query({ 'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=', 'list-type': 2, prefix: 'owner/repo/ref/' })
+      .query({
+        'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=',
+        'list-type': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, listReply[1])
       .put(/.*/)
       .matchHeader('x-amz-copy-source-if-match', 'abc')
@@ -732,10 +748,18 @@ describe('Storage test', () => {
     const putsHeaders = { s3: [], r2: [] };
     const heads = [];
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/ref/' })
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, listReply[0])
       .get('/')
-      .query({ 'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=', 'list-type': 2, prefix: 'owner/repo/ref/' })
+      .query({
+        'continuation-token': '1/s4dr7BSKNScrN4njX9+CpBNimYkuEzMWg3niTSAPMdculBmycyUPM6kv0xi46j4hdc1lFPkE/ICI8TxG+VNV9Hh91Ou0hqeBYzqTRzSBSs=',
+        'list-type': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, listReply[1])
       .head(/.*/)
       .times(10)
@@ -1109,7 +1133,11 @@ describe('Storage test', () => {
     });
     const deletes = { s3: [], r2: [] };
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/new-branch/' })
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'owner/repo/new-branch/',
+      })
       .reply(200, listReply)
       .post('/?delete=')
       .twice()
@@ -1144,7 +1172,11 @@ describe('Storage test', () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-reply.json'), 'utf-8'));
 
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/new-branch/' })
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'owner/repo/new-branch/',
+      })
       .reply(200, listReply.response)
       .post('/?delete=')
       .reply(404);
@@ -1158,7 +1190,11 @@ describe('Storage test', () => {
 
   it('rmdir works for empty dir', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/new-branch/' })
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'owner/repo/new-branch/',
+      })
       .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>helix-code-bus</Name><Prefix>owner/repo/new-branch/</Prefix><KeyCount>0</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>');
 
     const bus = storage.codeBus();
@@ -1167,7 +1203,12 @@ describe('Storage test', () => {
 
   it('list with empty prefix uses canonical S3 form (no leading slash)', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'foo/' })
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'foo/',
+      })
       .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>helix-code-bus</Name>
@@ -1207,11 +1248,19 @@ describe('Storage test', () => {
   it('listFolders returns just the folder paths', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'foo/' })
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'foo/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply[0]))
       .get('/')
       .query({
-        'continuation-token': 'next', delimiter: '/', 'list-type': 2, prefix: 'foo/',
+        'continuation-token': 'next',
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'foo/',
       })
       .reply(200, new xml2js.Builder().buildObject(listReply[1]));
 
@@ -1224,11 +1273,19 @@ describe('Storage test', () => {
   it('can list shallow across multiple pages', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'foo/' })
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'foo/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply[0]))
       .get('/')
       .query({
-        'continuation-token': 'next', delimiter: '/', 'list-type': 2, prefix: 'foo/',
+        'continuation-token': 'next',
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'foo/',
       })
       .reply(200, new xml2js.Builder().buildObject(listReply[1]));
 
@@ -1252,7 +1309,12 @@ describe('Storage test', () => {
   it('can list shallow', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-shallow-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'owner/repo/ref/' })
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1285,7 +1347,11 @@ describe('Storage test', () => {
   it('can list deep', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-deep-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ 'list-type': 2, prefix: 'owner/repo/ref/' })
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1322,7 +1388,12 @@ describe('Storage test', () => {
   it('shallow list returns mixed files and folders', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'owner/repo/ref/myfolder/' })
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'owner/repo/ref/myfolder/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1354,7 +1425,11 @@ describe('Storage test', () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-truncated-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/')
-      .query({ 'list-type': 2, 'max-keys': 2, prefix: 'owner/repo/ref/' })
+      .query({
+        'list-type': 2,
+        'max-keys': 2,
+        prefix: 'owner/repo/ref/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1385,7 +1460,10 @@ describe('Storage test', () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/')
       .query({
-        'list-type': 2, delimiter: '/', 'max-keys': 2, prefix: 'owner/repo/ref/',
+        'list-type': 2,
+        delimiter: '/',
+        'max-keys': 2,
+        prefix: 'owner/repo/ref/',
       })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
@@ -1416,7 +1494,12 @@ describe('Storage test', () => {
   it('browse navigates a sub-path', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'owner/repo/ref/myfolder/' })
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'owner/repo/ref/myfolder/',
+      })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
@@ -1445,7 +1528,10 @@ describe('Storage test', () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/')
       .query({
-        'list-type': 2, delimiter: '/', 'continuation-token': 'tok-1', prefix: 'owner/repo/ref/myfolder/',
+        'list-type': 2,
+        delimiter: '/',
+        'continuation-token': 'tok-1',
+        prefix: 'owner/repo/ref/myfolder/',
       })
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
@@ -1458,7 +1544,12 @@ describe('Storage test', () => {
 
   it('browse can return an empty page', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ delimiter: '/', 'list-type': 2, prefix: 'empty/' })
+      .get('/')
+      .query({
+        delimiter: '/',
+        'list-type': 2,
+        prefix: 'empty/',
+      })
       .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <KeyCount>0</KeyCount>
@@ -1473,7 +1564,11 @@ describe('Storage test', () => {
 
   it('copyDeep with empty dst places files at bucket root', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/').query({ 'list-type': 2, prefix: 'src/' })
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'src/',
+      })
       .reply(200, '<?xml version="1.0" encoding="UTF-8"?>'
         + '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
         + '<IsTruncated>false</IsTruncated>'

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1162,6 +1162,46 @@ describe('Storage test', () => {
     await bus.rmdir('/owner/repo/new-branch/');
   });
 
+  it('list with empty prefix uses canonical S3 form (no leading slash)', async () => {
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/?delimiter=%2F&list-type=2&prefix=foo%2F')
+      .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>helix-code-bus</Name>
+  <Prefix>foo/</Prefix>
+  <KeyCount>2</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>foo/bar.md</Key>
+    <LastModified>2021-05-05T08:00:30.000Z</LastModified>
+    <Size>11</Size>
+  </Contents>
+  <CommonPrefixes>
+    <Prefix>foo/sub/</Prefix>
+  </CommonPrefixes>
+</ListBucketResult>
+`);
+
+    const bus = storage.codeBus();
+    const result = await bus.list('', '/foo', { shallow: true });
+
+    assert.deepStrictEqual(result.objects, [
+      {
+        key: 'foo/sub/', path: '/foo/sub', name: 'sub', isFolder: true,
+      },
+      {
+        contentLength: 11,
+        contentType: 'text/markdown',
+        key: 'foo/bar.md',
+        lastModified: new Date('2021-05-05T08:00:30.000Z'),
+        path: '/foo/bar.md',
+        name: 'bar.md',
+        isFolder: false,
+      },
+    ]);
+  });
+
   it('can list shallow across multiple pages', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1162,18 +1162,28 @@ describe('Storage test', () => {
     await bus.rmdir('/owner/repo/new-branch/');
   });
 
-  it('can list folders', async () => {
+  it('can list shallow across multiple pages', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=')
+      .get('/?delimiter=%2F&list-type=2&prefix=foo%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply[0]))
-      .get('/?continuation-token=next&delimiter=%2F&list-type=2&prefix=')
+      .get('/?continuation-token=next&delimiter=%2F&list-type=2&prefix=foo%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply[1]));
 
     const bus = storage.codeBus();
-    const folders = await bus.listFolders('');
+    const result = await bus.list('foo', '/', { shallow: true });
 
-    assert.deepStrictEqual(folders, ['owner/', 'other/']);
+    assert.deepStrictEqual(result, {
+      objects: [
+        {
+          key: 'foo/owner/', path: '/owner', name: 'owner', isFolder: true,
+        },
+        {
+          key: 'foo/other/', path: '/other', name: 'other', isFolder: true,
+        },
+      ],
+      continuationToken: undefined,
+    });
   });
 
   it('can list shallow', async () => {
@@ -1183,26 +1193,31 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const folders = await bus.list('/owner/repo/ref/', true);
+    const result = await bus.list('/owner/repo/ref/', '/', { shallow: true });
 
-    assert.deepStrictEqual(folders, [
-      {
-        contentLength: 11,
-        contentType: null,
-        key: '/owner/repo/ref/.gitignore',
-        lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '.gitignore',
-        name: '.gitignore',
-      },
-      {
-        contentLength: 1234,
-        contentType: 'text/markdown',
-        key: '/owner/repo/ref/README.md',
-        lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: 'README.md',
-        name: 'README.md',
-      },
-    ]);
+    assert.deepStrictEqual(result, {
+      objects: [
+        {
+          contentLength: 11,
+          contentType: null,
+          key: '/owner/repo/ref/.gitignore',
+          lastModified: new Date('2021-05-05T08:00:30.000Z'),
+          path: '/.gitignore',
+          name: '.gitignore',
+          isFolder: false,
+        },
+        {
+          contentLength: 1234,
+          contentType: 'text/markdown',
+          key: '/owner/repo/ref/README.md',
+          lastModified: new Date('2021-05-05T08:00:30.000Z'),
+          path: '/README.md',
+          name: 'README.md',
+          isFolder: false,
+        },
+      ],
+      continuationToken: undefined,
+    });
   });
 
   it('can list deep', async () => {
@@ -1212,84 +1227,69 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const folders = await bus.list('/owner/repo/ref/', { includePrefixes: true });
+    const result = await bus.list('/owner/repo/ref/');
 
-    assert.deepStrictEqual(folders, [
+    assert.deepStrictEqual(result.objects, [
       {
         contentLength: 11,
         contentType: null,
         key: '/owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '.gitignore',
+        path: '/.gitignore',
         name: '.gitignore',
+        isFolder: false,
       },
       {
         contentLength: 1234,
         contentType: 'text/markdown',
         key: '/owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: 'README.md',
+        path: '/README.md',
         name: 'README.md',
+        isFolder: false,
       },
       {
         contentLength: 1234,
         contentType: 'text/javascript',
         key: '/owner/repo/ref/src/scripts.js',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: 'src/scripts.js',
+        path: '/src/scripts.js',
         name: 'scripts.js',
+        isFolder: false,
       },
     ]);
   });
 
-  it('can list to include subfolder prefixes', async () => {
+  it('shallow list returns mixed files and folders', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
+      .get('/?delimiter=%2F&list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const folders = await bus.list('/owner/repo/ref/myfolder/', { includePrefixes: true });
+    const result = await bus.list('/owner/repo/ref/', '/myfolder', { shallow: true });
 
-    assert.deepStrictEqual(folders, [
+    assert.deepStrictEqual(result.objects, [
       {
         key: '/owner/repo/ref/myfolder/sub1/',
-        path: 'sub1/',
+        path: '/myfolder/sub1',
         name: 'sub1',
+        isFolder: true,
       },
       {
         key: '/owner/repo/ref/myfolder/sub2/',
-        path: 'sub2/',
+        path: '/myfolder/sub2',
         name: 'sub2',
+        isFolder: true,
       },
       {
         contentLength: 999999,
         contentType: 'text/html',
         key: '/owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
-        path: 'somefile.html',
+        path: '/myfolder/somefile.html',
         name: 'somefile.html',
-      },
-    ]);
-  });
-
-  it('can list to not include subfolder prefixes', async () => {
-    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
-    nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
-      .reply(200, new xml2js.Builder().buildObject(listReply));
-
-    const bus = storage.codeBus();
-    const folders = await bus.list('/owner/repo/ref/myfolder/');
-
-    assert.deepStrictEqual(folders, [
-      {
-        contentLength: 999999,
-        contentType: 'text/html',
-        key: '/owner/repo/ref/myfolder/somefile.html',
-        lastModified: new Date('2021-06-06T04:05:06.000Z'),
-        path: 'somefile.html',
-        name: 'somefile.html',
+        isFolder: false,
       },
     ]);
   });
@@ -1302,27 +1302,26 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const items = await bus.list('/owner/repo/ref/', {
-      shallow: false,
-      maxItems: 2,
-    });
+    const result = await bus.list('/owner/repo/ref/', '/', { maxItems: 2 });
 
-    assert.deepStrictEqual(items, [
+    assert.deepStrictEqual(result.objects, [
       {
         contentLength: 11,
         contentType: null,
         key: '/owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '.gitignore',
+        path: '/.gitignore',
         name: '.gitignore',
+        isFolder: false,
       },
       {
         contentLength: 1234,
         contentType: 'text/markdown',
         key: '/owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: 'README.md',
+        path: '/README.md',
         name: 'README.md',
+        isFolder: false,
       },
     ]);
   });
@@ -1348,6 +1347,7 @@ describe('Storage test', () => {
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/.gitignore',
         name: '.gitignore',
+        isFolder: false,
       },
       {
         contentLength: 1234,
@@ -1356,23 +1356,28 @@ describe('Storage test', () => {
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
         path: '/README.md',
         name: 'README.md',
+        isFolder: false,
       },
     ]);
   });
 
-  it('browse navigates a sub-path with root-relative result paths', async () => {
+  it('browse navigates a sub-path with root-relative result paths and normalizes path', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/?delimiter=%2F&list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    // path is normalized: 'myfolder/' becomes '/myfolder/'
-    const result = await bus.browse('/owner/repo/ref/', 'myfolder/');
+    // 'myfolder' (no leading or trailing slash) is normalized to '/myfolder/'.
+    const result = await bus.browse('/owner/repo/ref/', 'myfolder');
 
     assert.deepStrictEqual(result.objects, [
-      { key: '/owner/repo/ref/myfolder/sub1/', path: '/myfolder/sub1/', name: 'sub1' },
-      { key: '/owner/repo/ref/myfolder/sub2/', path: '/myfolder/sub2/', name: 'sub2' },
+      {
+        key: '/owner/repo/ref/myfolder/sub1/', path: '/myfolder/sub1', name: 'sub1', isFolder: true,
+      },
+      {
+        key: '/owner/repo/ref/myfolder/sub2/', path: '/myfolder/sub2', name: 'sub2', isFolder: true,
+      },
       {
         contentLength: 999999,
         contentType: 'text/html',
@@ -1380,11 +1385,12 @@ describe('Storage test', () => {
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
         path: '/myfolder/somefile.html',
         name: 'somefile.html',
+        isFolder: false,
       },
     ]);
   });
 
-  it('browse forwards the continuation token and includes prefixes by default', async () => {
+  it('browse forwards the continuation token', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/')
@@ -1397,18 +1403,7 @@ describe('Storage test', () => {
     const result = await bus.browse('/owner/repo/ref/', '/myfolder/', { continuationToken: 'tok-1' });
 
     assert.strictEqual(result.continuationToken, undefined);
-    assert.deepStrictEqual(result.objects, [
-      { key: '/owner/repo/ref/myfolder/sub1/', path: '/myfolder/sub1/', name: 'sub1' },
-      { key: '/owner/repo/ref/myfolder/sub2/', path: '/myfolder/sub2/', name: 'sub2' },
-      {
-        contentLength: 999999,
-        contentType: 'text/html',
-        key: '/owner/repo/ref/myfolder/somefile.html',
-        lastModified: new Date('2021-06-06T04:05:06.000Z'),
-        path: '/myfolder/somefile.html',
-        name: 'somefile.html',
-      },
-    ]);
+    assert.strictEqual(result.objects.length, 3);
   });
 
   it('browse can return an empty page', async () => {
@@ -1424,42 +1419,6 @@ describe('Storage test', () => {
     const result = await bus.browse('empty');
 
     assert.deepStrictEqual(result, { objects: [], continuationToken: undefined });
-  });
-
-  it('browse can omit prefixes', async () => {
-    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
-    nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
-      .reply(200, new xml2js.Builder().buildObject(listReply));
-
-    const bus = storage.codeBus();
-    const result = await bus.browse('/owner/repo/ref/', '/myfolder/', { includePrefixes: false });
-
-    assert.deepStrictEqual(result.objects, [
-      {
-        contentLength: 999999,
-        contentType: 'text/html',
-        key: '/owner/repo/ref/myfolder/somefile.html',
-        lastModified: new Date('2021-06-06T04:05:06.000Z'),
-        path: '/myfolder/somefile.html',
-        name: 'somefile.html',
-      },
-    ]);
-  });
-
-  it('can return an empty list of folders', async () => {
-    nock('https://helix-code-bus.s3.fake.amazonaws.com')
-      .get('/?delimiter=%2F&list-type=2&prefix=foo%2f')
-      .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
-<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <KeyCount>0</KeyCount>
-</ListBucketResult>
-`);
-
-    const bus = storage.codeBus();
-    const folders = await bus.listFolders('foo/');
-
-    assert.deepStrictEqual(folders, []);
   });
 });
 

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1316,6 +1316,98 @@ describe('Storage test', () => {
     ]);
   });
 
+  it('can browse a single page with continuation', async () => {
+    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-truncated-reply.json'), 'utf-8'));
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/')
+      .query({
+        'list-type': 2, delimiter: '/', 'max-keys': 2, prefix: '/owner/repo/ref/',
+      })
+      .reply(200, new xml2js.Builder().buildObject(listReply));
+
+    const bus = storage.codeBus();
+    const result = await bus.browse('/owner/repo/ref/', { maxItems: 2 });
+
+    assert.strictEqual(result.continuationToken, 'next');
+    assert.deepStrictEqual(result.objects, [
+      {
+        contentLength: 11,
+        contentType: null,
+        key: '/owner/repo/ref/.gitignore',
+        lastModified: new Date('2021-05-05T08:00:30.000Z'),
+        path: '.gitignore',
+      },
+      {
+        contentLength: 1234,
+        contentType: 'text/markdown',
+        key: '/owner/repo/ref/README.md',
+        lastModified: new Date('2021-05-05T08:00:30.000Z'),
+        path: 'README.md',
+      },
+    ]);
+  });
+
+  it('browse forwards the continuation token and includes prefixes by default', async () => {
+    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/')
+      .query({
+        'list-type': 2, delimiter: '/', 'continuation-token': 'tok-1', prefix: '/owner/repo/ref/myfolder/',
+      })
+      .reply(200, new xml2js.Builder().buildObject(listReply));
+
+    const bus = storage.codeBus();
+    const result = await bus.browse('/owner/repo/ref/myfolder/', { continuationToken: 'tok-1' });
+
+    assert.strictEqual(result.continuationToken, undefined);
+    assert.deepStrictEqual(result.objects, [
+      { key: '/owner/repo/ref/myfolder/sub1/', path: 'sub1/' },
+      { key: '/owner/repo/ref/myfolder/sub2/', path: 'sub2/' },
+      {
+        contentLength: 999999,
+        contentType: 'text/html',
+        key: '/owner/repo/ref/myfolder/somefile.html',
+        lastModified: new Date('2021-06-06T04:05:06.000Z'),
+        path: 'somefile.html',
+      },
+    ]);
+  });
+
+  it('browse can return an empty page', async () => {
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/?delimiter=%2F&list-type=2&prefix=empty%2F')
+      .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <KeyCount>0</KeyCount>
+</ListBucketResult>
+`);
+
+    const bus = storage.codeBus();
+    const result = await bus.browse('empty/');
+
+    assert.deepStrictEqual(result, { objects: [], continuationToken: undefined });
+  });
+
+  it('browse can omit prefixes', async () => {
+    const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/?delimiter=%2F&list-type=2&prefix=%2Fowner%2Frepo%2Fref%2Fmyfolder%2F')
+      .reply(200, new xml2js.Builder().buildObject(listReply));
+
+    const bus = storage.codeBus();
+    const result = await bus.browse('/owner/repo/ref/myfolder/', { includePrefixes: false });
+
+    assert.deepStrictEqual(result.objects, [
+      {
+        contentLength: 999999,
+        contentType: 'text/html',
+        key: '/owner/repo/ref/myfolder/somefile.html',
+        lastModified: new Date('2021-06-06T04:05:06.000Z'),
+        path: 'somefile.html',
+      },
+    ]);
+  });
+
   it('can return an empty list of folders', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/?delimiter=%2F&list-type=2&prefix=foo%2f')

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1184,18 +1184,17 @@ describe('Storage test', () => {
 `);
 
     const bus = storage.codeBus();
-    const result = await bus.list('', '/foo', { shallow: true });
+    const result = await bus.list('foo', { shallow: true });
 
     assert.deepStrictEqual(result.objects, [
       {
-        key: 'foo/sub/', path: '/foo/sub', name: 'sub', isFolder: true,
+        key: 'foo/sub/', name: 'sub', isFolder: true,
       },
       {
         contentLength: 11,
         contentType: 'text/markdown',
         key: 'foo/bar.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '/foo/bar.md',
         name: 'bar.md',
         isFolder: false,
       },
@@ -1213,7 +1212,7 @@ describe('Storage test', () => {
     const bus = storage.codeBus();
     const folders = await bus.listFolders('foo');
 
-    assert.deepStrictEqual(folders, ['/owner', '/other']);
+    assert.deepStrictEqual(folders, ['owner', 'other']);
   });
 
   it('can list shallow across multiple pages', async () => {
@@ -1225,15 +1224,16 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply[1]));
 
     const bus = storage.codeBus();
-    const result = await bus.list('foo', '/', { shallow: true });
+    const result = await bus.list('foo', { shallow: true });
 
     assert.deepStrictEqual(result, {
+      prefix: 'foo/',
       objects: [
         {
-          key: 'foo/owner/', path: '/owner', name: 'owner', isFolder: true,
+          key: 'foo/owner/', name: 'owner', isFolder: true,
         },
         {
-          key: 'foo/other/', path: '/other', name: 'other', isFolder: true,
+          key: 'foo/other/', name: 'other', isFolder: true,
         },
       ],
       continuationToken: undefined,
@@ -1247,16 +1247,16 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.list('/owner/repo/ref/', '/', { shallow: true });
+    const result = await bus.list('owner/repo/ref/', { shallow: true });
 
     assert.deepStrictEqual(result, {
+      prefix: 'owner/repo/ref/',
       objects: [
         {
           contentLength: 11,
           contentType: null,
           key: 'owner/repo/ref/.gitignore',
           lastModified: new Date('2021-05-05T08:00:30.000Z'),
-          path: '/.gitignore',
           name: '.gitignore',
           isFolder: false,
         },
@@ -1265,7 +1265,6 @@ describe('Storage test', () => {
           contentType: 'text/markdown',
           key: 'owner/repo/ref/README.md',
           lastModified: new Date('2021-05-05T08:00:30.000Z'),
-          path: '/README.md',
           name: 'README.md',
           isFolder: false,
         },
@@ -1281,7 +1280,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.list('/owner/repo/ref/');
+    const result = await bus.list('owner/repo/ref/');
 
     assert.deepStrictEqual(result.objects, [
       {
@@ -1289,7 +1288,6 @@ describe('Storage test', () => {
         contentType: null,
         key: 'owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '/.gitignore',
         name: '.gitignore',
         isFolder: false,
       },
@@ -1298,7 +1296,6 @@ describe('Storage test', () => {
         contentType: 'text/markdown',
         key: 'owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '/README.md',
         name: 'README.md',
         isFolder: false,
       },
@@ -1307,7 +1304,6 @@ describe('Storage test', () => {
         contentType: 'text/javascript',
         key: 'owner/repo/ref/src/scripts.js',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '/src/scripts.js',
         name: 'scripts.js',
         isFolder: false,
       },
@@ -1321,18 +1317,16 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.list('/owner/repo/ref/', '/myfolder', { shallow: true });
+    const result = await bus.list('owner/repo/ref/myfolder/', { shallow: true });
 
     assert.deepStrictEqual(result.objects, [
       {
         key: 'owner/repo/ref/myfolder/sub1/',
-        path: '/myfolder/sub1',
         name: 'sub1',
         isFolder: true,
       },
       {
         key: 'owner/repo/ref/myfolder/sub2/',
-        path: '/myfolder/sub2',
         name: 'sub2',
         isFolder: true,
       },
@@ -1341,7 +1335,6 @@ describe('Storage test', () => {
         contentType: 'text/html',
         key: 'owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
-        path: '/myfolder/somefile.html',
         name: 'somefile.html',
         isFolder: false,
       },
@@ -1356,7 +1349,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.list('/owner/repo/ref/', '/', { maxItems: 2 });
+    const result = await bus.list('owner/repo/ref/', { maxItems: 2 });
 
     assert.deepStrictEqual(result.objects, [
       {
@@ -1364,7 +1357,6 @@ describe('Storage test', () => {
         contentType: null,
         key: 'owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '/.gitignore',
         name: '.gitignore',
         isFolder: false,
       },
@@ -1373,7 +1365,6 @@ describe('Storage test', () => {
         contentType: 'text/markdown',
         key: 'owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '/README.md',
         name: 'README.md',
         isFolder: false,
       },
@@ -1390,7 +1381,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.browse('/owner/repo/ref/', '/', { maxItems: 2 });
+    const result = await bus.browse('owner/repo/ref/', { maxItems: 2 });
 
     assert.strictEqual(result.continuationToken, 'next');
     assert.deepStrictEqual(result.objects, [
@@ -1399,7 +1390,6 @@ describe('Storage test', () => {
         contentType: null,
         key: 'owner/repo/ref/.gitignore',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '/.gitignore',
         name: '.gitignore',
         isFolder: false,
       },
@@ -1408,36 +1398,33 @@ describe('Storage test', () => {
         contentType: 'text/markdown',
         key: 'owner/repo/ref/README.md',
         lastModified: new Date('2021-05-05T08:00:30.000Z'),
-        path: '/README.md',
         name: 'README.md',
         isFolder: false,
       },
     ]);
   });
 
-  it('browse navigates a sub-path with root-relative result paths and normalizes path', async () => {
+  it('browse navigates a sub-path', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-subfolder-prefixes.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .get('/?delimiter=%2F&list-type=2&prefix=owner%2Frepo%2Fref%2Fmyfolder%2F')
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    // 'myfolder' (no leading or trailing slash) is normalized to '/myfolder/'.
-    const result = await bus.browse('/owner/repo/ref/', 'myfolder');
+    const result = await bus.browse('owner/repo/ref/myfolder/');
 
     assert.deepStrictEqual(result.objects, [
       {
-        key: 'owner/repo/ref/myfolder/sub1/', path: '/myfolder/sub1', name: 'sub1', isFolder: true,
+        key: 'owner/repo/ref/myfolder/sub1/', name: 'sub1', isFolder: true,
       },
       {
-        key: 'owner/repo/ref/myfolder/sub2/', path: '/myfolder/sub2', name: 'sub2', isFolder: true,
+        key: 'owner/repo/ref/myfolder/sub2/', name: 'sub2', isFolder: true,
       },
       {
         contentLength: 999999,
         contentType: 'text/html',
         key: 'owner/repo/ref/myfolder/somefile.html',
         lastModified: new Date('2021-06-06T04:05:06.000Z'),
-        path: '/myfolder/somefile.html',
         name: 'somefile.html',
         isFolder: false,
       },
@@ -1454,7 +1441,7 @@ describe('Storage test', () => {
       .reply(200, new xml2js.Builder().buildObject(listReply));
 
     const bus = storage.codeBus();
-    const result = await bus.browse('/owner/repo/ref/', '/myfolder/', { continuationToken: 'tok-1' });
+    const result = await bus.browse('owner/repo/ref/myfolder/', { continuationToken: 'tok-1' });
 
     assert.strictEqual(result.continuationToken, undefined);
     assert.strictEqual(result.objects.length, 3);
@@ -1472,7 +1459,27 @@ describe('Storage test', () => {
     const bus = storage.codeBus();
     const result = await bus.browse('empty');
 
-    assert.deepStrictEqual(result, { objects: [], continuationToken: undefined });
+    assert.deepStrictEqual(result, { prefix: 'empty/', objects: [], continuationToken: undefined });
+  });
+
+  it('copyDeep with empty dst places files at bucket root', async () => {
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/?list-type=2&prefix=src%2F')
+      .reply(200, '<?xml version="1.0" encoding="UTF-8"?>'
+        + '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        + '<IsTruncated>false</IsTruncated>'
+        + '<Contents><Key>src/foo.txt</Key><LastModified>2021-05-05T08:00:30.000Z</LastModified><Size>10</Size></Contents>'
+        + '</ListBucketResult>')
+      .put('/foo.txt?x-id=CopyObject')
+      .reply(200, '<?xml version="1.0" encoding="UTF-8"?><CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2021-05-05T08:37:23.000Z</LastModified><ETag>&quot;abc&quot;</ETag></CopyObjectResult>');
+    nock(`https://helix-code-bus.${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`)
+      .put('/foo.txt?x-id=CopyObject')
+      .reply(200, '<?xml version="1.0" encoding="UTF-8"?><CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2021-05-05T08:37:23.000Z</LastModified><ETag>&quot;abc&quot;</ETag></CopyObjectResult>');
+
+    const bus = storage.codeBus();
+    const changes = await bus.copyDeep('src/', '');
+    assert.strictEqual(changes.length, 1);
+    assert.strictEqual(changes[0].dst, 'foo.txt');
   });
 });
 


### PR DESCRIPTION
## Summary

Refactors the `Bucket` listing API in `helix-shared-storage` for clarity and consistency.

- **`sanitizePrefix` helper**: new private function that strips leading/trailing slashes then appends one trailing slash — canonical S3 directory-prefix form. Used by `list` and `browse`.
- **`list()` returns `ListResult`**: was `ObjectInfo[]`, now `{ prefix, objects, continuationToken }`. Callers destructure `.objects`. Also drops the `boolean` shorthand for `opts`.
- **`browse()` added**: new paginated listing method with `continuationToken` and `maxItems` support, returns same `ListResult` shape.
- **`listFolders()` returns basenames**: was returning raw S3 `CommonPrefix` strings like `['owner/repo/ref/blog/']`; now returns `['blog']`.
- **`ObjectInfo` cleaned up**: drops `path` (computed redundancy), adds `name` (basename) and `isFolder` (boolean). `lastModified` is now a `Date` (was `string`). `contentLength`/`contentType` are optional and only present for files.
- **Tests**: all nock query strings replaced with `.query({})` objects (one property per line); new coverage tests for empty-prefix listing and `copyDeep` to bucket root.

## Breaking changes

| What changed | Before | After |
|---|---|---|
| `list()` return type | `Promise<ObjectInfo[]>` | `Promise<ListResult>` — destructure `.objects` |
| `list()` `opts` parameter | `boolean \| ListOptions` | `ListOptions` only — no boolean shorthand |
| `ListOptions.includePrefixes` | present | **removed** — use `shallow: true` and filter `isFolder` |
| `ObjectInfo.path` | `string` (relative, no leading `/`) | **removed** |
| `ObjectInfo.lastModified` | `string` | `Date` |
| `ObjectInfo.contentLength` / `contentType` | required `number` / `string` | optional, files only |
| `listFolders()` return values | full S3 CommonPrefix strings e.g. `['owner/repo/ref/blog/']` | basenames e.g. `['blog']` |

## New additions (non-breaking)

- `browse(prefix, opts?)` — paginated single-page listing with `continuationToken` and `maxItems`
- `ObjectInfo.name` — basename of the key
- `ObjectInfo.isFolder` — `true` for folder entries (was `CommonPrefixes`), `false` for files
- `ListResult.prefix` — the sanitized S3 prefix that was actually queried

## Test plan

- [x] `npm test` in `packages/helix-shared-storage` — all 62 tests pass
- [x] 100% branch coverage (`c8`)
- [x] `npm run lint` — no errors