### PR TITLE
fix(storage): correctly set isFolder for folder placeholders in deep list

### DIFF
--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -151,10 +151,11 @@ function listResultToObjectInfos(result) {
   });
   (result.Contents || []).forEach((content) => {
     const key = content.Key;
+    const isFolder = key.endsWith('/');
     objects.push({
       key,
       name: basename(key),
-      isFolder: false,
+      isFolder,
       lastModified: content.LastModified,
       contentLength: content.Size,
       contentType: mime.getType(key),

--- a/packages/helix-shared-storage/test/storage.test.js
+++ b/packages/helix-shared-storage/test/storage.test.js
@@ -1319,6 +1319,56 @@ describe('Storage test', () => {
     ]);
   });
 
+  it('deep list marks folder placeholder keys (trailing /) as isFolder=true', async () => {
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .get('/')
+      .query({
+        'list-type': 2,
+        prefix: 'foo/',
+      })
+      .reply(200, `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>helix-code-bus</Name>
+  <Prefix>foo/</Prefix>
+  <KeyCount>2</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>foo/sub/</Key>
+    <LastModified>2021-05-05T08:00:30.000Z</LastModified>
+    <Size>0</Size>
+  </Contents>
+  <Contents>
+    <Key>foo/bar.md</Key>
+    <LastModified>2021-05-05T08:00:30.000Z</LastModified>
+    <Size>11</Size>
+  </Contents>
+</ListBucketResult>
+`);
+
+    const bus = storage.codeBus();
+    const result = await bus.list('foo');
+
+    assert.deepStrictEqual(result.objects, [
+      {
+        key: 'foo/sub/',
+        name: 'sub',
+        isFolder: true,
+        lastModified: new Date('2021-05-05T08:00:30.000Z'),
+        contentLength: 0,
+        contentType: null,
+      },
+      {
+        key: 'foo/bar.md',
+        name: 'bar.md',
+        isFolder: false,
+        lastModified: new Date('2021-05-05T08:00:30.000Z'),
+        contentLength: 11,
+        contentType: 'text/markdown',
+      },
+    ]);
+  });
+
   it('listFolders returns just the folder paths', async () => {
     const listReply = JSON.parse(await fs.readFile(path.resolve(__testdir, 'fixtures', 'list-folders-reply.json'), 'utf-8'));
     nock('https://helix-code-bus.s3.fake.amazonaws.com')


### PR DESCRIPTION
## Summary

- When `list()` is called without `shallow: true`, S3 returns zero-byte folder placeholder keys (e.g. `documents/`) in `Contents` rather than `CommonPrefixes` since no `Delimiter` is used
- `listResultToObjectInfos` was hardcoding `isFolder: false` for all `Contents` entries, so these placeholders were incorrectly reported as files
- Fixed by deriving `isFolder` from `key.endsWith('/')` instead

## Test plan

- [x] Added new test case: `deep list marks folder placeholder keys (trailing /) as isFolder=true` — verifies a zero-byte `foo/sub/` key gets `isFolder: true` and a regular file gets `isFolder: false`
- [x] All 64 existing tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)