### PR TITLE
feat(tokencache): add deserializeHook option to S3CachePlugin

### DIFF
--- a/packages/helix-shared-tokencache/src/S3CacheManager.d.ts
+++ b/packages/helix-shared-tokencache/src/S3CacheManager.d.ts
@@ -17,6 +17,7 @@ export declare interface S3CacheManagerOptions {
   bucket: string;
   prefix: string;
   secret: string;
+  deserializeHook?: (data: object, log: Console) => void;
 }
 
 export declare class S3CacheManager {

--- a/packages/helix-shared-tokencache/src/S3CacheManager.js
+++ b/packages/helix-shared-tokencache/src/S3CacheManager.js
@@ -49,6 +49,8 @@ export class S3CacheManager {
     this.secret = opts.secret;
     this.readOnly = opts.readOnly;
     this.type = opts.type;
+    this.deserializeHook = opts.deserializeHook;
+
     const disableExpectContinueHeader = opts.disableExpectContinueHeader
       ?? (process.env.HELIX_HTTP_S3_DISABLE_EXPECT_CONTINUE === 'true');
     this.s3 = new S3Client({
@@ -109,6 +111,7 @@ export class S3CacheManager {
       secret: this.secret,
       bucket: this.bucket,
       readOnly: this.readOnly,
+      deserializeHook: this.deserializeHook,
     });
   }
 }

--- a/packages/helix-shared-tokencache/src/S3CachePlugin.d.ts
+++ b/packages/helix-shared-tokencache/src/S3CachePlugin.d.ts
@@ -17,6 +17,7 @@ export declare interface S3CachePluginOptions {
   key: string;
   secret: string;
   readOnly?: boolean;
+  deserializeHook?: (data: object, log: Console) => void;
 }
 
 export declare class S3CachePlugin implements CachePlugin {

--- a/packages/helix-shared-tokencache/src/S3CachePlugin.js
+++ b/packages/helix-shared-tokencache/src/S3CachePlugin.js
@@ -41,6 +41,8 @@ export class S3CachePlugin {
     this.secret = opts.secret;
     this.readOnly = opts.readOnly || false;
     this.type = opts.type;
+    this.deserializeHook = opts.deserializeHook;
+
     const disableExpectContinueHeader = opts.disableExpectContinueHeader
       ?? (process.env.HELIX_HTTP_S3_DISABLE_EXPECT_CONTINUE === 'true');
     this.s3 = new S3Client({
@@ -85,6 +87,8 @@ export class S3CachePlugin {
         raw = raw.toString('utf-8');
       }
       const data = JSON.parse(raw);
+      this.deserializeHook?.(data, log);
+
       if (data.cachePluginMetadata) {
         this.meta = data.cachePluginMetadata;
         delete data.cachePluginMetadata;

--- a/packages/helix-shared-tokencache/src/getCachePlugin.js
+++ b/packages/helix-shared-tokencache/src/getCachePlugin.js
@@ -50,6 +50,7 @@ export async function getCachePlugin(opts, type) {
     readOnly = false,
     contentBucket = BUCKET_CONTENT_BUS,
     codeBucket = BUCKET_CODE_BUS,
+    deserializeHook,
   } = opts;
 
   const derivedOpts = [];
@@ -74,6 +75,7 @@ export async function getCachePlugin(opts, type) {
     bucket: contentBucket,
     type,
     readOnly,
+    deserializeHook,
   }, ...derivedOpts);
 
   log.info(`using connected user from ${basePlugin.location}`);

--- a/packages/helix-shared-tokencache/test/S3CachePlugin.test.js
+++ b/packages/helix-shared-tokencache/test/S3CachePlugin.test.js
@@ -19,6 +19,7 @@ import { Nock, toAuthContent } from './utils.js';
 describe('S3CachePlugin Test', () => {
   let nock;
   let savedProcessEnv;
+
   beforeEach(() => {
     nock = new Nock();
     savedProcessEnv = process.env;
@@ -398,6 +399,35 @@ describe('S3CachePlugin Test', () => {
     const ret = await p.beforeCacheAccess(ctx);
     assert.strictEqual(ret, false);
     assert.strictEqual(ctx.token, '');
+  });
+
+  it('invokes deserializeHook with parsed data and log on load', async () => {
+    let hookedData = null;
+    let hookedLog = null;
+
+    const p = new S3CachePlugin({
+      bucket: 'test-bucket',
+      key: 'myproject/auth-default/json',
+      secret: '',
+      deserializeHook: (data, log) => {
+        hookedData = data;
+        hookedLog = log;
+        // eslint-disable-next-line no-param-reassign
+        delete data.AccessToken;
+      },
+    });
+
+    nock('https://test-bucket.s3.us-east-1.amazonaws.com')
+      .get('/myproject/auth-default/json?x-id=GetObject')
+      .reply(200, JSON.stringify(toAuthContent('1234')));
+
+    const ctx = new MockTokenCacheContext({});
+    await p.beforeCacheAccess(ctx);
+
+    assert.ok(hookedData, 'deserializeHook was called');
+    assert.strictEqual(hookedLog, p.log);
+    assert.strictEqual(ctx.token, '1234');
+    assert.strictEqual(hookedData.AccessToken, undefined);
   });
 
   it('deletes the cache from s3', async () => {


### PR DESCRIPTION
## Summary

- Adds an optional `deserializeHook` callback to `S3CachePlugin`, `S3CacheManager`, and `getCachePlugin`
- The hook is called with the parsed token cache object and the plugin logger immediately after loading from S3, allowing callers to inspect or mutate the data before MSAL deserializes it
- Propagated through the full option chain: `getCachePlugin` → `S3CacheManager` → `S3CachePlugin`
- Type declarations updated in both `.d.ts` files

## Test plan

- [ ] `npm test --workspace=@adobe/helix-shared-tokencache` passes
- [ ] New test `invokes deserializeHook with parsed data and log on load` verifies the hook is called with the correct arguments and that mutations take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)