### PR TITLE
feat(storage): add backend-agnostic conditional-copy support to CopyOptions

### DIFF
--- a/packages/helix-shared-storage-azure/src/AzureBackend.js
+++ b/packages/helix-shared-storage-azure/src/AzureBackend.js
@@ -267,9 +267,13 @@ export class AzureBackend extends AbstractStorageBackend {
   /**
    * @param {string} src already-sanitized source key
    * @param {string} dst already-sanitized destination key
-   * @param {import('@adobe/helix-shared-storage').CopyOptions} [opts]
+   * @param {import('@adobe/helix-shared-storage').CopyOptions} [opts] `ifMatch`/`ifNoneMatch`
+   *  map onto `beginCopyFromURL`'s `conditions.ifMatch`/`conditions.ifNoneMatch` (destination);
+   *  `sourceIfMatch` maps onto `sourceConditions.ifMatch`
    * @returns {Promise<import('@adobe/helix-shared-storage').CommonObjectMeta>}
-   * @throws an error with `status: 404` if the source object does not exist
+   * @throws an error with `status: 404` if the source object does not exist; `status` is
+   *  otherwise normalized from `statusCode` for any other failure (e.g. a failed precondition,
+   *  typically 412)
    */
   async copy(src, dst, opts = {}) {
     const srcBlobClient = this._client.getBlobClient(src);
@@ -283,6 +287,19 @@ export class AzureBackend extends AbstractStorageBackend {
     const copyOpts = { ...opts.copyOpts };
     if (opts.metadataDirective === 'REPLACE') {
       copyOpts.metadata = opts.metadata ?? {};
+    }
+    // Normalized conditional-copy preconditions (see `CopyOptions` in `@adobe/helix-shared-
+    // storage`) map directly onto the Azure SDK's own `conditions`/`sourceConditions` shape —
+    // only include the destination `conditions` bag at all when one of its fields is actually
+    // set, so we never send an empty object that could confuse the SDK/service.
+    if (opts.ifMatch !== undefined || opts.ifNoneMatch !== undefined) {
+      copyOpts.conditions = {
+        ...(opts.ifMatch !== undefined && { ifMatch: opts.ifMatch }),
+        ...(opts.ifNoneMatch !== undefined && { ifNoneMatch: opts.ifNoneMatch }),
+      };
+    }
+    if (opts.sourceIfMatch !== undefined) {
+      copyOpts.sourceConditions = { ifMatch: opts.sourceIfMatch };
     }
 
     try {
@@ -298,13 +315,17 @@ export class AzureBackend extends AbstractStorageBackend {
       this._log.info(`object copied from ${this._bucketName}/${src} to: ${this._bucketName}/${dst}`);
       return { etag: raw.etag, raw };
     } catch (e) {
-      /* c8 ignore next 3 */
-      if (e.statusCode !== 404) {
-        throw e;
+      if (e.statusCode === 404) {
+        const e2 = new Error(`source does not exist: ${this._bucketName}/${src}`);
+        e2.status = 404;
+        throw e2;
       }
-      const e2 = new Error(`source does not exist: ${this._bucketName}/${src}`);
-      e2.status = 404;
-      throw e2;
+      // Normalize the native error's HTTP status onto `.status`, same convention as the 404
+      // case above, so callers (e.g. optimistic-concurrency retry logic keying off a failed
+      // `ifMatch`/`ifNoneMatch`/`sourceIfMatch` precondition) can branch on it without knowing
+      // this is an Azure SDK error shape.
+      e.status = e.statusCode;
+      throw e;
     }
   }
 

--- a/packages/helix-shared-storage-azure/test/storage.test.js
+++ b/packages/helix-shared-storage-azure/test/storage.test.js
@@ -339,6 +339,45 @@ describe('AzureBackend storage test', () => {
     );
   });
 
+  it('maps ifMatch/ifNoneMatch onto destination conditions', async () => {
+    nock(BASE_URL)
+      .put('/helix-code-bus/dst')
+      .matchHeader('if-match', '"dest-etag"')
+      .matchHeader('if-none-match', '*')
+      .reply(202, '', {
+        etag: '"abc"',
+        'x-ms-copy-id': 'copy-1',
+        'x-ms-copy-status': 'success',
+      });
+    const raw = await backend.copy('src', 'dst', { ifMatch: '"dest-etag"', ifNoneMatch: '*' });
+    assert.strictEqual(raw.etag, '"abc"');
+  });
+
+  it('maps sourceIfMatch onto source conditions', async () => {
+    nock(BASE_URL)
+      .put('/helix-code-bus/dst')
+      .matchHeader('x-ms-source-if-match', '"src-etag"')
+      .reply(202, '', {
+        etag: '"abc"',
+        'x-ms-copy-id': 'copy-1',
+        'x-ms-copy-status': 'success',
+      });
+    const raw = await backend.copy('src', 'dst', { sourceIfMatch: '"src-etag"' });
+    assert.strictEqual(raw.etag, '"abc"');
+  });
+
+  it('normalizes a non-404 copy error\'s status onto e.status', async () => {
+    nock(BASE_URL)
+      .put('/helix-code-bus/dst')
+      .reply(412, '<?xml version="1.0" encoding="utf-8"?><Error><Code>ConditionNotMet</Code></Error>', {
+        'content-type': 'application/xml',
+      });
+    await assert.rejects(
+      backend.copy('src', 'dst', { ifNoneMatch: '*' }),
+      (e) => e.status === 412,
+    );
+  });
+
   it('can remove a single object', async () => {
     nock(BASE_URL)
       .delete('/helix-code-bus/foo')

--- a/packages/helix-shared-storage-s3/src/S3Backend.js
+++ b/packages/helix-shared-storage-s3/src/S3Backend.js
@@ -65,7 +65,9 @@ const GET_META_FIELDS = {
  * `CopyObjectCommand` equivalent. Excluded from the raw `copyOpts` passthrough so that only the
  * mapped PascalCase field ends up in the command input, never both spellings.
  */
-const COMMON_COPY_FIELD_NAMES = new Set([...SYSTEM_META_FIELD_NAMES, 'metadata', 'metadataDirective']);
+const COMMON_COPY_FIELD_NAMES = new Set([
+  ...SYSTEM_META_FIELD_NAMES, 'metadata', 'metadataDirective', 'ifMatch', 'ifNoneMatch', 'sourceIfMatch',
+]);
 
 /**
  * Returns the last segment of a key, treating an optional trailing `/` as a folder separator.
@@ -278,9 +280,13 @@ export class S3Backend extends AbstractStorageBackend {
   /**
    * @param {string} src already-sanitized source key
    * @param {string} dst already-sanitized destination key
-   * @param {import('@adobe/helix-shared-storage').CopyOptions} [opts]
+   * @param {import('@adobe/helix-shared-storage').CopyOptions} [opts] `ifMatch`/`ifNoneMatch`
+   *  map onto `CopyObjectCommand`'s own `IfMatch`/`IfNoneMatch`; `sourceIfMatch` maps onto
+   *  `CopySourceIfMatch`
    * @returns {Promise<import('@adobe/helix-shared-storage').CommonObjectMeta>}
-   * @throws an error with `status: 404` if the source object does not exist
+   * @throws an error with `status: 404` if the source object does not exist; `status` is
+   *  otherwise normalized from `$metadata.httpStatusCode` for any other failure (e.g. a
+   *  failed precondition, typically 412 or 409)
    */
   async copy(src, dst, opts = {}) {
     // `opts` carries raw, backend-native passthrough fields flattened at the top level by
@@ -302,7 +308,13 @@ export class S3Backend extends AbstractStorageBackend {
       CopySource: `${this._bucketName}/${src}`,
       Key: dst,
     };
-    const systemFields = { Metadata: opts.metadata, MetadataDirective: opts.metadataDirective };
+    const systemFields = {
+      Metadata: opts.metadata,
+      MetadataDirective: opts.metadataDirective,
+      IfMatch: opts.ifMatch,
+      IfNoneMatch: opts.ifNoneMatch,
+      CopySourceIfMatch: opts.sourceIfMatch,
+    };
     Object.entries(SYSTEM_META_FIELDS).forEach(([common, pascal]) => {
       systemFields[pascal] = opts[common];
     });
@@ -316,13 +328,18 @@ export class S3Backend extends AbstractStorageBackend {
       this._log.info(`object copied from ${input.CopySource} to: ${input.Bucket}/${input.Key}`);
       return { etag: raw.CopyObjectResult?.ETag, raw };
     } catch (e) {
-      /* c8 ignore next 3 */
-      if (e.Code !== 'NoSuchKey') {
-        throw e;
+      const status = e.$metadata?.httpStatusCode;
+      if (e.Code === 'NoSuchKey' || status === 404) {
+        const e2 = new Error(`source does not exist: ${input.CopySource}`);
+        e2.status = 404;
+        throw e2;
       }
-      const e2 = new Error(`source does not exist: ${input.CopySource}`);
-      e2.status = 404;
-      throw e2;
+      // Normalize the native error's HTTP status onto `.status`, same convention as the 404
+      // case above, so callers (e.g. optimistic-concurrency retry logic keying off a failed
+      // `ifMatch`/`ifNoneMatch`/`sourceIfMatch` precondition) can branch on it without knowing
+      // this is an AWS SDK error shape.
+      e.status = status;
+      throw e;
     }
   }
 

--- a/packages/helix-shared-storage-s3/test/storage.test.js
+++ b/packages/helix-shared-storage-s3/test/storage.test.js
@@ -1232,6 +1232,42 @@ describe('Storage test', () => {
     );
   });
 
+  it('maps normalized ifMatch/ifNoneMatch/sourceIfMatch onto their CopyObjectCommand fields', async () => {
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .put('/owner/repo/ref/foo/bar.md?x-id=CopyObject')
+      .matchHeader('if-match', '"dest-etag"')
+      .matchHeader('if-none-match', '*')
+      .matchHeader('x-amz-copy-source-if-match', '"src-etag"')
+      .reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n<CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2021-05-05T08:37:23.000Z</LastModified><ETag>&quot;f278c0035a9b4398629613a33abe6451&quot;</ETag></CopyObjectResult>');
+
+    const bus = storage.codeBus({ disableR2: true });
+    await bus.copy(
+      '/owner/repo/ref/foo.md',
+      '/owner/repo/ref/foo/bar.md',
+      {
+        ifMatch: '"dest-etag"',
+        ifNoneMatch: '*',
+        sourceIfMatch: '"src-etag"',
+      },
+    );
+  });
+
+  it('normalizes a non-404 copy error\'s status onto e.status', async () => {
+    const body = '<?xml version="1.0" encoding="UTF-8"?><Error><Code>PreconditionFailed</Code><Message>At least one of the pre-conditions you specified did not hold</Message></Error>';
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .put('/owner/repo/ref/foo/bar.md?x-id=CopyObject')
+      .reply(412, body);
+
+    const bus = storage.codeBus({ disableR2: true });
+    await assert.rejects(
+      bus.copy('/owner/repo/ref/foo.md', '/owner/repo/ref/foo/bar.md', { ifNoneMatch: '*' }),
+      (e) => {
+        assert.strictEqual(e.status, 412);
+        return true;
+      },
+    );
+  });
+
   it('an explicit copyOpts.ContentType is not clobbered when no metadata mutation is requested', async () => {
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .put('/owner/repo/ref/foo/bar.md?x-id=CopyObject')

--- a/packages/helix-shared-storage/src/AbstractStorageBackend.js
+++ b/packages/helix-shared-storage/src/AbstractStorageBackend.js
@@ -71,6 +71,15 @@ export const SYSTEM_META_FIELD_NAMES = [
  * @property {string} [contentLanguage]
  * @property {Object.<string, string>} [metadata]
  * @property {'COPY'|'REPLACE'} [metadataDirective]
+ * @property {string} [ifMatch] normalized destination precondition — implementors should map
+ *  this onto their native "only if destination etag matches" mechanism (e.g. S3's `IfMatch`
+ *  on `CopyObjectCommand`; Azure's `conditions.ifMatch` on `beginCopyFromURL`)
+ * @property {string} [ifNoneMatch] normalized destination precondition, typically `'*'` —
+ *  implementors should map this onto their native "only if destination doesn't exist"
+ *  mechanism (e.g. S3's `IfNoneMatch`; Azure's `conditions.ifNoneMatch`)
+ * @property {string} [sourceIfMatch] normalized source precondition — implementors should map
+ *  this onto their native "only if source etag still matches" mechanism (e.g. S3's
+ *  `CopySourceIfMatch`; Azure's `sourceConditions.ifMatch`)
  * @property {Object.<string, *>} [copyOpts] additional backend-native fields to merge into
  *  the underlying copy call, verbatim
  */
@@ -150,7 +159,11 @@ export const SYSTEM_META_FIELD_NAMES = [
  * @property {function(string, string, CopyOptions=): Promise<CommonObjectMeta>} copy copy an
  *  object within the same bucket; already-resolved `opts` (system headers + metadata) are
  *  provided by {@link Bucket} when the copy needs to preserve/rewrite metadata; backends
- *  should normalize a missing source into an error with `status: 404`
+ *  should normalize a missing source into an error with `status: 404`, and — like that
+ *  existing 404 convention — should normalize *any* thrown error's native HTTP status onto
+ *  `status` (e.g. a failed `ifMatch`/`ifNoneMatch`/`sourceIfMatch` precondition, typically
+ *  412 or 409), so callers can branch on `e.status` without knowing the backend's native
+ *  error shape
  * @property {function((string|string[]), RemoveOptions=): Promise<RemoveOutcome>} remove
  *  remove one or more objects; when passed an array, the backend owns any batching/chunking
  *  required by its own service limits

--- a/packages/helix-shared-storage/src/Bucket.js
+++ b/packages/helix-shared-storage/src/Bucket.js
@@ -283,14 +283,18 @@ export class Bucket {
    * @returns {Promise<import('./AbstractStorageBackend.js').CopyOptions|null>}
    */
   async _buildCopyOptions(srcKey, opts) {
+    const {
+      ifMatch, ifNoneMatch, sourceIfMatch, copyOpts,
+    } = opts;
+    const conditions = { ifMatch, ifNoneMatch, sourceIfMatch };
     if (!opts.addMetadata && !opts.renameMetadata) {
-      return { ...opts.copyOpts };
+      return { ...conditions, ...copyOpts };
     }
     const head = await this._backend.head(srcKey);
     if (!head) {
       return null;
     }
-    const copyOptions = { ...opts.copyOpts };
+    const copyOptions = { ...conditions, ...copyOpts };
     SYSTEM_META_FIELD_NAMES.forEach((field) => {
       if (head[field] !== undefined) {
         copyOptions[field] = head[field];
@@ -304,13 +308,17 @@ export class Bucket {
   /**
    * Copy an object within the same bucket. When `addMetadata` or `renameMetadata` are
    * provided, the source's HEAD is consulted so that selected system headers are preserved
-   * and metadata is rewritten with `metadataDirective: 'REPLACE'`.
+   * and metadata is rewritten with `metadataDirective: 'REPLACE'`. `ifMatch`/`ifNoneMatch`
+   * (destination) and `sourceIfMatch` (source) are normalized, backend-agnostic conditional
+   * preconditions — see {@link import('./storage.js').CopyOptions}.
    *
    * @param {string} src source key
    * @param {string} dst destination key
    * @param {import('./storage.js').CopyOptions} [opts]
    * @returns {Promise<CommonObjectMeta|undefined>}
-   * @throws an error with `status: 404` if the source object does not exist
+   * @throws an error with `status: 404` if the source object does not exist; `status` is
+   *  otherwise normalized from the backend's native error for any other failure (e.g. a
+   *  failed precondition, typically `status: 412` or `409`)
    */
   async copy(src, dst, opts = {}) {
     const srcKey = sanitizeKey(src);

--- a/packages/helix-shared-storage/src/storage.js
+++ b/packages/helix-shared-storage/src/storage.js
@@ -43,6 +43,16 @@ import { Bucket } from './Bucket.js';
  *  Use `addMetadata` to keep the `from` property as well.
  * @property {Object.<string, string>} [addMetadata] metadata to merge with existing metadata.
  *  Properties are applied after `renameMetadata`.
+ * @property {string} [ifMatch] destination precondition: the copy only succeeds if the
+ *  destination object's current etag equals this value (guards an overwrite against
+ *  concurrent changes). Normalized across backends — see {@link StorageBackend#copy}.
+ * @property {string} [ifNoneMatch] destination precondition: pass `'*'` so the copy only
+ *  succeeds if no object currently exists at the destination (optimistic create). Normalized
+ *  across backends — see {@link StorageBackend#copy}.
+ * @property {string} [sourceIfMatch] source precondition: the copy only succeeds if the
+ *  *source* object's current etag still equals this value (guards against copying a source
+ *  that changed since it was last read). Normalized across backends — see
+ *  {@link StorageBackend#copy}.
  * @property {Object.<string, *>} [copyOpts] additional, backend-native fields to merge into
  *  the underlying copy call (e.g. AWS's `CacheControl`, `ContentType`, `Tagging`, ...).
  */

--- a/packages/helix-shared-storage/test/Bucket.test.js
+++ b/packages/helix-shared-storage/test/Bucket.test.js
@@ -264,6 +264,34 @@ describe('Bucket', () => {
       assert.strictEqual(backend.objects.get('bar').Tagging, 'x=1');
     });
 
+    it('forwards normalized ifMatch/ifNoneMatch/sourceIfMatch alongside copyOpts (no metadata mutation)', async () => {
+      await bucket.put('/foo', 'hello', 'text/plain', {}, false);
+      await bucket.copy('/foo', '/bar', {
+        ifMatch: '"dest-etag"',
+        ifNoneMatch: '*',
+        sourceIfMatch: '"src-etag"',
+        copyOpts: { Tagging: 'x=1' },
+      });
+      const obj = backend.objects.get('bar');
+      assert.strictEqual(obj.ifMatch, '"dest-etag"');
+      assert.strictEqual(obj.ifNoneMatch, '*');
+      assert.strictEqual(obj.sourceIfMatch, '"src-etag"');
+      assert.strictEqual(obj.Tagging, 'x=1');
+    });
+
+    it('forwards normalized ifMatch/ifNoneMatch/sourceIfMatch when addMetadata also triggers a HEAD', async () => {
+      await bucket.put('/foo', 'hello', 'text/plain', { existing: '1' }, false);
+      await bucket.copy('/foo', '/bar', {
+        addMetadata: { added: '2' },
+        ifNoneMatch: '*',
+        sourceIfMatch: '"src-etag"',
+      });
+      const obj = backend.objects.get('bar');
+      assert.strictEqual(obj.ifNoneMatch, '*');
+      assert.strictEqual(obj.sourceIfMatch, '"src-etag"');
+      assert.deepStrictEqual(obj.metadata, { existing: '1', added: '2' });
+    });
+
     it('unwraps result.raw.CopyObjectResult when the backend nests one under raw', async () => {
       backend.copy = async () => ({ etag: 'x', raw: { CopyObjectResult: { ETag: 'x' } } });
       const result = await bucket.copy('/foo', '/bar');


### PR DESCRIPTION
## Summary
- Adds `ifMatch`/`ifNoneMatch` (destination) and `sourceIfMatch` (source) as normalized, backend-agnostic `CopyOptions` fields, following the same pattern already established by `metadataDirective`.
- Closes a real gap surfaced while migrating `helix-azure-api-service` off S3: conditional-copy predicates could previously only be expressed via the untyped, backend-native `copyOpts` escape hatch (e.g. S3's `IfMatch`/`IfNoneMatch`/`CopySourceIfMatch`), so optimistic-concurrency copy logic built against that shape silently became a no-op once a caller switched to `StorageAzure` (Azure's SDK expects a completely different `conditions`/`sourceConditions` shape).
- `S3Backend#copy()` maps the new fields onto `CopyObjectCommand`'s native `IfMatch`/`IfNoneMatch`/`CopySourceIfMatch`.
- `AzureBackend#copy()` maps them onto `beginCopyFromURL`'s `conditions`/`sourceConditions`.
- Both backends' `copy()` now normalize *any* thrown error's native HTTP status onto `e.status` (previously only the "source missing" 404 case was normalized), so callers can branch on precondition failures (412/409) without knowing the backend's native error shape.

## Why
`helix-azure-api-service`'s `source-client.js` implements optimistic-create ("copy only if destination doesn't exist") and optimistic-update/versioning ("copy only if destination/source etag still matches") on top of `Bucket#copy()`, using raw AWS-SDK-v3 field names passed through `copyOpts`. This worked against the old S3-only backend, but is inert against `StorageAzure`. Rather than teaching application code about each backend's native option shape, this extends the storage abstraction itself — the same way `metadataDirective: 'COPY'|'REPLACE'` already abstracts over S3's `MetadataDirective` vs. Azure's separate `setHTTPHeaders()` call.

## Test plan
- [x] `npm test` in `helix-shared-storage`, `helix-shared-storage-s3`, `helix-shared-storage-azure` — all at 100% coverage (existing threshold), new tests added for: destination `ifMatch`/`ifNoneMatch` mapping, source `sourceIfMatch` mapping, and non-404 error-status normalization, for both backends.
- [x] `npm test --workspaces` from the repo root — all packages pass, no regressions.
- [x] `npm run lint` in each touched package — clean.

Follow-up (separate, out of scope here): once this is released, `helix-azure-api-service`'s `source-client.js` will be updated to use the new normalized fields instead of its current raw `copyOpts` passthrough, and its currently-skipped copy-semantics tests will be un-skipped against real Azure behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)