### PR TITLE
feat(storage): add streaming putStream() to the storage backend interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1123.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1123.0.tgz",
-      "integrity": "sha512-InD/KXgF4clIFtqo8yzQQG755/BBoLstsC5WITLrMckKUUaACQgbpbZcdsySAXU3Uukp/3RV0Aiv5H3eDNGXcw==",
+      "version": "3.1127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1127.0.tgz",
+      "integrity": "sha512-0ZSAgmEda33xPqVPt+bx2KzrXV1cUCKRRVPGliLu+V7DzHPa04CqPSi1maGEM4O0LDP0iI6HRSW5ULloNwayNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.29",
@@ -431,6 +431,36 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.1127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1127.0.tgz",
+      "integrity": "sha512-em87TJQOrdE3sAqlMnhg3HUAVj1hcoGdDjpekzDdKQcyQSKKbFfulnV57j41h/dHJxVqXRGzTqS8QOdOPtNFtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.1127.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
@@ -2907,7 +2937,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6668,7 +6697,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6789,7 +6817,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -12739,7 +12766,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -13097,7 +13123,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -14157,6 +14182,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -14219,7 +14254,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -15329,7 +15363,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -16373,6 +16406,7 @@
         "@adobe/helix-shared-process-queue": "^3.0.4",
         "@adobe/helix-shared-storage": "^3.0.0",
         "@aws-sdk/client-s3": "^3.1030.0",
+        "@aws-sdk/lib-storage": "^3.1030.0",
         "@smithy/node-http-handler": "^4.0.0",
         "mime": "^4.0.3"
       },

--- a/packages/helix-shared-storage-azure/src/AzureBackend.js
+++ b/packages/helix-shared-storage-azure/src/AzureBackend.js
@@ -82,6 +82,21 @@ function fromAzureMetadata(metadata = {}) {
 }
 
 /**
+ * Maps the common, lowerCamelCase system-property fields on `opts` (e.g. `contentType`) onto
+ * Azure's `BlobHTTPHeaders` shape, shared by `AzureBackend#put`/`AzureBackend#putStream`.
+ *
+ * @param {import('@adobe/helix-shared-storage').PutOptions} opts
+ * @returns {Object.<string, string>}
+ */
+function buildBlobHTTPHeaders(opts) {
+  const blobHTTPHeaders = {};
+  Object.entries(SYSTEM_META_FIELDS).forEach(([common, azure]) => {
+    blobHTTPHeaders[azure] = opts[common];
+  });
+  return blobHTTPHeaders;
+}
+
+/**
  * Maps a downloaded blob's HTTP headers into the common, lowerCamelCase `CommonObjectMeta`
  * field names, shared by `get()`'s `meta` output and `head()`'s return value. Falls back to a
  * `content_encoding` custom metadata property when the native `Content-Encoding` header is
@@ -219,12 +234,30 @@ export class AzureBackend extends AbstractStorageBackend {
   async put(key, body, opts = {}) {
     const data = typeof body === 'string' ? Buffer.from(body) : body;
     const blockBlobClient = this._client.getBlockBlobClient(key);
-    const blobHTTPHeaders = {};
-    Object.entries(SYSTEM_META_FIELDS).forEach(([common, azure]) => {
-      blobHTTPHeaders[azure] = opts[common];
-    });
     const raw = await blockBlobClient.upload(data, data.length, {
-      blobHTTPHeaders,
+      blobHTTPHeaders: buildBlobHTTPHeaders(opts),
+      metadata: toAzureMetadata(opts.metadata),
+    });
+    this._log.info(`object uploaded to: ${this._bucketName}/${key}`);
+    return {
+      etag: raw.etag, contentType: opts.contentType, raw,
+    };
+  }
+
+  /**
+   * Streams `body` to Azure via `BlockBlobClient.uploadStream()`, which reads and uploads the
+   * stream in chunks instead of requiring the length upfront — Azure's equivalent of S3's
+   * `Upload` helper.
+   *
+   * @param {string} key already-sanitized object key
+   * @param {import('node:stream').Readable} body data to store
+   * @param {import('@adobe/helix-shared-storage').PutOptions} [opts]
+   * @returns {Promise<import('@adobe/helix-shared-storage').CommonObjectMeta>}
+   */
+  async putStream(key, body, opts = {}) {
+    const blockBlobClient = this._client.getBlockBlobClient(key);
+    const raw = await blockBlobClient.uploadStream(body, undefined, undefined, {
+      blobHTTPHeaders: buildBlobHTTPHeaders(opts),
       metadata: toAzureMetadata(opts.metadata),
     });
     this._log.info(`object uploaded to: ${this._bucketName}/${key}`);

--- a/packages/helix-shared-storage-azure/test/storage.test.js
+++ b/packages/helix-shared-storage-azure/test/storage.test.js
@@ -12,6 +12,7 @@
 
 /* eslint-env mocha */
 import assert from 'assert';
+import { Readable } from 'node:stream';
 import { promisify } from 'util';
 import zlib from 'zlib';
 import { BlobServiceClient, StorageSharedKeyCredential } from '@azure/storage-blob';
@@ -229,6 +230,20 @@ describe('AzureBackend storage test', () => {
       .reply(201, '', { etag: '"abc"' });
     const raw = await backend.put('foo', Buffer.from('hello, world.'));
     assert.strictEqual(raw.etag, '"abc"');
+  });
+
+  it('can put a stream (staged block + commit block list, unlike put()\'s single upload())', async () => {
+    nock(BASE_URL)
+      .put((uri) => uri.startsWith('/helix-code-bus/foo?comp=block&blockid='))
+      .reply(201)
+      .put('/helix-code-bus/foo?comp=blocklist')
+      .matchHeader('x-ms-blob-content-type', 'text/plain')
+      .matchHeader('x-ms-meta-myid', '1234')
+      .reply(201, '', { etag: '"abc"' });
+    const stream = Readable.from([Buffer.from('hello, world.')]);
+    const raw = await backend.putStream('foo', stream, { contentType: 'text/plain', metadata: { myid: '1234' } });
+    assert.strictEqual(raw.etag, '"abc"');
+    assert.strictEqual(raw.contentType, 'text/plain');
   });
 
   it('put substitutes `-` with `_` in metadata keys (Azure does not allow `-`)', async () => {

--- a/packages/helix-shared-storage-s3/package.json
+++ b/packages/helix-shared-storage-s3/package.json
@@ -39,6 +39,7 @@
     "@adobe/helix-shared-process-queue": "^3.0.4",
     "@adobe/helix-shared-storage": "^3.0.0",
     "@aws-sdk/client-s3": "^3.1030.0",
+    "@aws-sdk/lib-storage": "^3.1030.0",
     "@smithy/node-http-handler": "^4.0.0",
     "mime": "^4.0.3"
   }

--- a/packages/helix-shared-storage-s3/src/S3Backend.js
+++ b/packages/helix-shared-storage-s3/src/S3Backend.js
@@ -22,6 +22,7 @@ import {
   ListObjectsV2Command,
   PutObjectCommand,
 } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
 import { Response } from '@adobe/fetch';
 import mime from 'mime';
 import processQueue from '@adobe/helix-shared-process-queue';
@@ -223,12 +224,14 @@ export class S3Backend extends AbstractStorageBackend {
   }
 
   /**
+   * Builds the shared `PutObjectCommand`/`Upload` input for `put()`/`putStream()`.
+   *
    * @param {string} key already-sanitized object key
-   * @param {Buffer|string} body data to store
-   * @param {import('@adobe/helix-shared-storage').PutOptions} [opts]
-   * @returns {Promise<import('@adobe/helix-shared-storage').CommonObjectMeta>}
+   * @param {Buffer|string|import('node:stream').Readable} body
+   * @param {import('@adobe/helix-shared-storage').PutOptions} opts
+   * @returns {Object.<string, *>}
    */
-  async put(key, body, opts = {}) {
+  _buildPutInput(key, body, opts) {
     const input = {
       Body: body,
       Bucket: this._bucketName,
@@ -238,7 +241,37 @@ export class S3Backend extends AbstractStorageBackend {
     Object.entries(SYSTEM_META_FIELDS).forEach(([common, pascal]) => {
       input[pascal] = opts[common];
     });
+    return input;
+  }
+
+  /**
+   * @param {string} key already-sanitized object key
+   * @param {Buffer|string} body data to store
+   * @param {import('@adobe/helix-shared-storage').PutOptions} [opts]
+   * @returns {Promise<import('@adobe/helix-shared-storage').CommonObjectMeta>}
+   */
+  async put(key, body, opts = {}) {
+    const input = this._buildPutInput(key, body, opts);
     const raw = await this._client.send(new PutObjectCommand(input));
+    this._log.info(`object uploaded to: ${input.Bucket}/${input.Key}`);
+    return {
+      etag: raw.ETag, versionId: raw.VersionId, contentType: opts.contentType, raw,
+    };
+  }
+
+  /**
+   * Streams `body` to S3 via `@aws-sdk/lib-storage`'s `Upload` helper, which transparently
+   * switches to a multipart upload for large streams instead of requiring the length upfront.
+   *
+   * @param {string} key already-sanitized object key
+   * @param {import('node:stream').Readable} body data to store
+   * @param {import('@adobe/helix-shared-storage').PutOptions} [opts]
+   * @returns {Promise<import('@adobe/helix-shared-storage').CommonObjectMeta>}
+   */
+  async putStream(key, body, opts = {}) {
+    const input = this._buildPutInput(key, body, opts);
+    const upload = new Upload({ client: this._client, params: input });
+    const raw = await upload.done();
     this._log.info(`object uploaded to: ${input.Bucket}/${input.Key}`);
     return {
       etag: raw.ETag, versionId: raw.VersionId, contentType: opts.contentType, raw,

--- a/packages/helix-shared-storage-s3/test/storage.test.js
+++ b/packages/helix-shared-storage-s3/test/storage.test.js
@@ -12,6 +12,7 @@
 
 /* eslint-env mocha */
 import { Agent } from 'node:https';
+import { Readable } from 'node:stream';
 import { Response } from '@adobe/fetch';
 import assert from 'assert';
 import { promises as fs } from 'fs';
@@ -324,6 +325,46 @@ describe('Storage test', () => {
     await bus.put('/foo', 'hello, world.', 'text/plain', {
       myid: '1234',
     }, false);
+
+    const req = {
+      '/foo?x-id=PutObject': {
+        body: Buffer.from('hello, world.', 'utf-8'),
+        headers: {
+          'content-type': 'text/plain',
+          'x-amz-meta-myid': '1234',
+        },
+      },
+    };
+    assert.deepEqual(reqs.s3, req);
+    assert.deepEqual(reqs.r2, req);
+  });
+
+  it('can put a stream (small enough to use a single PutObject, not multipart)', async () => {
+    const reqs = { s3: {}, r2: {} };
+    nock('https://helix-code-bus.s3.fake.amazonaws.com')
+      .put('/foo?x-id=PutObject')
+      .reply(function cb(uri) {
+        reqs.s3[uri] = {
+          body: Buffer.concat(this.req.requestBodyBuffers),
+          headers: Object.fromEntries(Object.entries(this.req.headers)
+            .filter(([key]) => TEST_HEADERS.indexOf(key) >= 0)),
+        };
+        return [201];
+      });
+    nock(`https://helix-code-bus.${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`)
+      .put('/foo?x-id=PutObject')
+      .reply(function cb(uri) {
+        reqs.r2[uri] = {
+          body: Buffer.concat(this.req.requestBodyBuffers),
+          headers: Object.fromEntries(Object.entries(this.req.headers)
+            .filter(([key]) => TEST_HEADERS.indexOf(key) >= 0)),
+        };
+        return [201];
+      });
+
+    const bus = storage.codeBus();
+    const stream = Readable.from([Buffer.from('hello, world.', 'utf-8')]);
+    await bus.putStream('/foo', stream, 'text/plain', { myid: '1234' });
 
     const req = {
       '/foo?x-id=PutObject': {

--- a/packages/helix-shared-storage/src/AbstractStorageBackend.js
+++ b/packages/helix-shared-storage/src/AbstractStorageBackend.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import { buffer } from 'node:stream/consumers';
+
 /**
  * Common, backend-agnostic object metadata fields (lowerCamelCase). Every {@link StorageBackend}
  * method that returns object metadata returns (at least) these fields, plus the backend's raw,
@@ -123,9 +125,11 @@ export const SYSTEM_META_FIELD_NAMES = [
  * Implementors need to provide the 7 mandatory primitives below (`putMeta` is mandatory
  * rather than a generic default because a correct, efficient implementation is inherently
  * backend-specific — e.g. S3's self-copy trick vs. Azure's native `setMetadata`); `metadata`,
- * `getMeta`, `listFolders`, and `browse` have generic default implementations in
+ * `getMeta`, `listFolders`, `browse`, and `putStream` have generic default implementations in
  * {@link AbstractStorageBackend}, overridable for efficiency (e.g. Azure can implement
- * `listFolders` via `listBlobsByHierarchy` instead of the generic list+filter fallback).
+ * `listFolders` via `listBlobsByHierarchy` instead of the generic list+filter fallback, or S3
+ * can implement `putStream` via a real multipart upload instead of the generic
+ * buffer-then-`put()` fallback).
  *
  * @typedef {Object} StorageBackend
  * @property {string} name backend family tag used for error tagging when mirrored, e.g.
@@ -147,6 +151,12 @@ export const SYSTEM_META_FIELD_NAMES = [
  *  default, since `head()` already normalizes system fields into these common names
  * @property {function(string, (Buffer|string), PutOptions=): Promise<CommonObjectMeta>} put
  *  store an object's contents along with metadata/system headers
+ * @property {function(string, import('node:stream').Readable, PutOptions=):
+ *   Promise<CommonObjectMeta>} putStream
+ *  store an object's contents from a `Readable`, without requiring its length upfront; generic
+ *  default in {@link AbstractStorageBackend} buffers the stream fully then delegates to `put()`
+ *  — backends that can do real chunked/multipart streaming (S3's `Upload` from
+ *  `@aws-sdk/lib-storage`, Azure's `uploadStream()`) should override this for large payloads
  * @property {function(string, Object.<string, string>): Promise<CommonObjectMeta>} putMeta
  *  replace an object's metadata. `meta` may mix custom keys with common system-property field
  *  names (e.g. `contentType`); it's up to the backend to recognize and apply those
@@ -183,9 +193,9 @@ export const SYSTEM_META_FIELD_NAMES = [
 /**
  * Convenience base class for {@link StorageBackend} implementations. Subclasses only need to
  * implement the 7 mandatory primitives (`get`, `head`, `put`, `copy`, `remove`, `list`,
- * `putMeta`) to get all 11 interface methods for free; `metadata`/`getMeta`/`listFolders`/
- * `browse` have generic default bodies here, in terms of the mandatory primitives, overridable
- * for efficiency.
+ * `putMeta`) to get all 12 interface methods for free; `metadata`/`getMeta`/`listFolders`/
+ * `browse`/`putStream` have generic default bodies here, in terms of the mandatory primitives,
+ * overridable for efficiency.
  *
  * @implements {StorageBackend}
  */
@@ -216,6 +226,22 @@ export class AbstractStorageBackend {
 
   async list() {
     throw new Error('list() not implemented');
+  }
+
+  /**
+   * Generic default: buffers the stream fully, then delegates to {@link StorageBackend#put}.
+   * Works for any backend without extra work, but defeats the purpose of streaming for large
+   * payloads — backends that can do real chunked/multipart uploads (S3's `Upload` helper,
+   * Azure's `uploadStream()`) should override this.
+   *
+   * @param {string} key
+   * @param {import('node:stream').Readable} stream
+   * @param {PutOptions} [opts]
+   * @returns {Promise<CommonObjectMeta>}
+   */
+  async putStream(key, stream, opts = {}) {
+    const body = await buffer(stream);
+    return this.put(key, body, opts);
   }
 
   /**

--- a/packages/helix-shared-storage/src/Bucket.js
+++ b/packages/helix-shared-storage/src/Bucket.js
@@ -258,6 +258,26 @@ export class Bucket {
   }
 
   /**
+   * Store an object's contents from a `Readable`, without requiring its length or fully
+   * buffering it in memory — for large, already-compressed binary payloads (e.g. media) where
+   * `put()`'s always-buffer-and-gzip behavior would be wasteful or wrong. There is no `compress`
+   * option: compressing a streamed upload isn't supported. Mirrored to any secondary backends
+   * configured on the resolved `StorageBackend`.
+   *
+   * @param {string} path object key
+   * @param {import('node:stream').Readable} stream data to store
+   * @param {string} [contentType] content type. Defaults to `application/octet-stream`.
+   * @param {Record<string, string>} [meta] metadata to store with the object. Defaults to `{}`.
+   * @returns {Promise<CommonObjectMeta>}
+   */
+  async putStream(path, stream, contentType = 'application/octet-stream', meta = {}) {
+    const dstKey = sanitizeKey(path);
+    const res = await this._backend.putStream(dstKey, stream, { contentType, metadata: meta });
+    this._log.info(`object uploaded to: ${this.bucket}/${dstKey}`);
+    return res;
+  }
+
+  /**
    * Replace an object's metadata. `meta` may mix custom, user-defined keys with any of the
    * common system-property field names (e.g. `contentType`); it's up to the backend to
    * recognize and apply those appropriately (e.g. S3 maps `contentType` onto its own

--- a/packages/helix-shared-storage/src/MirroringBackend.js
+++ b/packages/helix-shared-storage/src/MirroringBackend.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import { PassThrough } from 'node:stream';
+
 /**
  * @typedef {Object} MirroringBackendOptions
  * @property {import('./AbstractStorageBackend.js').StorageBackend} primary
@@ -81,12 +83,14 @@ export class MirroringBackend {
   }
 
   /**
-   * Fans `method(...args)` out to every backend in parallel. Returns the primary's result if
-   * all succeed; otherwise throws the first-failing backend's error (array order), tagged
-   * with `[<backend.name>] ` on its message.
+   * Fans a set of per-backend calls out in parallel, one thunk per entry in `this._backends`
+   * (same order). Returns the primary's (first) result if all succeed; otherwise throws the
+   * first-failing backend's error (array order), tagged with `[<backend.name>] ` on its message.
+   *
+   * @param {Array<function(): Promise<*>>} calls
    */
-  async _fanOut(method, args) {
-    const settled = await Promise.allSettled(this._backends.map((b) => b[method](...args)));
+  async _fanOutCalls(calls) {
+    const settled = await Promise.allSettled(calls.map((call) => call()));
     const zipped = settled.map((result, i) => ({ backend: this._backends[i], result }));
     const rejected = zipped.filter(({ result }) => result.status === 'rejected');
     if (!rejected.length) {
@@ -98,8 +102,36 @@ export class MirroringBackend {
     throw err;
   }
 
+  /**
+   * Fans `method(...args)` out to every backend in parallel, with the same `args` for each.
+   */
+  _fanOut(method, args) {
+    return this._fanOutCalls(this._backends.map((b) => () => b[method](...args)));
+  }
+
   put(...args) {
     return this._fanOut('put', args);
+  }
+
+  /**
+   * Streams `body` to every backend in parallel. A single backend streams the source directly;
+   * 2+ backends tee it into one `PassThrough` per backend first, since a `Readable` can only be
+   * consumed once — mirrors `helix-mediahandler`'s pre-existing S3+R2 dual-write pattern. A read
+   * error on the source stream is forwarded to every tee, so a broken source aborts all
+   * in-flight uploads instead of leaving them hanging.
+   *
+   * @param {string} key
+   * @param {import('node:stream').Readable} stream
+   * @param {import('./AbstractStorageBackend.js').PutOptions} [opts]
+   */
+  putStream(key, stream, opts) {
+    if (this._backends.length === 1) {
+      return this._primary.putStream(key, stream, opts);
+    }
+    const tees = this._backends.map(() => new PassThrough());
+    stream.on('error', (err) => tees.forEach((tee) => tee.destroy(err)));
+    tees.forEach((tee) => stream.pipe(tee));
+    return this._fanOutCalls(this._backends.map((b, i) => () => b.putStream(key, tees[i], opts)));
   }
 
   copy(...args) {

--- a/packages/helix-shared-storage/test/AbstractStorageBackend.test.js
+++ b/packages/helix-shared-storage/test/AbstractStorageBackend.test.js
@@ -12,6 +12,7 @@
 
 /* eslint-env mocha */
 import assert from 'assert';
+import { Readable } from 'node:stream';
 import { AbstractStorageBackend } from '../src/AbstractStorageBackend.js';
 
 class MinimalBackend extends AbstractStorageBackend {
@@ -27,6 +28,11 @@ class MinimalBackend extends AbstractStorageBackend {
 
   async list() {
     return this._listResult;
+  }
+
+  async put(key, body, opts) {
+    this.putCall = { key, body, opts };
+    return { etag: 'fake-etag' };
   }
 }
 
@@ -81,6 +87,18 @@ describe('AbstractStorageBackend', () => {
         objects: [{ key: 'foo/bar.md', name: 'bar.md', isFolder: false }],
         continuationToken: undefined,
       });
+    });
+
+    it('putStream() buffers the stream fully, then delegates to put()', async () => {
+      const backend = new MinimalBackend();
+      const stream = Readable.from([Buffer.from('hello world')]);
+      const opts = { contentType: 'text/plain' };
+
+      const result = await backend.putStream('foo', stream, opts);
+      assert.deepStrictEqual(result, { etag: 'fake-etag' });
+      assert.strictEqual(backend.putCall.key, 'foo');
+      assert.strictEqual(backend.putCall.body.toString(), 'hello world');
+      assert.strictEqual(backend.putCall.opts, opts);
     });
   });
 

--- a/packages/helix-shared-storage/test/Bucket.test.js
+++ b/packages/helix-shared-storage/test/Bucket.test.js
@@ -12,6 +12,7 @@
 
 /* eslint-env mocha */
 import assert from 'assert';
+import { Readable } from 'node:stream';
 import { Response } from '@adobe/fetch';
 import { AbstractStorageBackend } from '../src/AbstractStorageBackend.js';
 import { Bucket } from '../src/Bucket.js';
@@ -169,6 +170,18 @@ describe('Bucket', () => {
       const obj = backend.objects.get('foo');
       assert.strictEqual(obj.body.toString('utf-8'), 'hello, world.');
       assert.strictEqual(obj.contentEncoding, undefined);
+    });
+  });
+
+  describe('putStream()', () => {
+    it('delegates to the backend, sanitizing the key, without compressing', async () => {
+      const stream = Readable.from([Buffer.from('hello, world.')]);
+      await bucket.putStream('/foo', stream, 'text/plain', { a: '1' });
+      const obj = backend.objects.get('foo');
+      assert.strictEqual(obj.body.toString('utf-8'), 'hello, world.');
+      assert.strictEqual(obj.contentEncoding, undefined);
+      assert.strictEqual(obj.contentType, 'text/plain');
+      assert.deepStrictEqual(obj.metadata, { a: '1' });
     });
   });
 

--- a/packages/helix-shared-storage/test/MirroringBackend.test.js
+++ b/packages/helix-shared-storage/test/MirroringBackend.test.js
@@ -12,6 +12,8 @@
 
 /* eslint-env mocha */
 import assert from 'assert';
+import { PassThrough, Readable } from 'node:stream';
+import { buffer as readStreamBuffer } from 'node:stream/consumers';
 import { MirroringBackend } from '../src/MirroringBackend.js';
 
 /**
@@ -19,13 +21,16 @@ import { MirroringBackend } from '../src/MirroringBackend.js';
  * fixed error, for every method.
  */
 class FakeBackend {
-  constructor(name, { fails = false, value = `${name}-value`, client = `${name}-client` } = {}) {
+  constructor(name, {
+    fails = false, value = `${name}-value`, client = `${name}-client`, consumeStream = false,
+  } = {}) {
     this.name = name;
     this.bucketName = 'fake-bucket';
     this.client = client;
     this.calls = {};
     this._fails = fails;
     this._value = value;
+    this._consumeStream = consumeStream;
   }
 
   async _invoke(method, args) {
@@ -57,6 +62,21 @@ class FakeBackend {
   remove(...args) { return this._invoke('remove', args); }
 
   putMeta(...args) { return this._invoke('putMeta', args); }
+
+  /**
+   * When `consumeStream` is set, actually reads the given stream (recording the full body on
+   * `this.received`) instead of the generic `_invoke()` behavior, which would ignore it —
+   * needed to verify `MirroringBackend#putStream`'s teeing actually delivers the full body to
+   * every backend, not just that it was called.
+   */
+  async putStream(key, stream, opts) {
+    if (!this._consumeStream) {
+      return this._invoke('putStream', [key, stream, opts]);
+    }
+    this.calls.putStream = (this.calls.putStream || 0) + 1;
+    this.received = await readStreamBuffer(stream);
+    return { method: 'putStream', value: this._value };
+  }
 }
 
 describe('MirroringBackend', () => {
@@ -145,6 +165,48 @@ describe('MirroringBackend', () => {
         assert.strictEqual(primary.calls[method], 1);
         assert.strictEqual(r2.calls[method], 1);
         assert.strictEqual(azure.calls[method], 1);
+      });
+    });
+  });
+
+  describe('putStream()', () => {
+    it('streams directly to the primary when there is a single backend (no tee)', async () => {
+      const primary = new FakeBackend('S3');
+      const mirror = new MirroringBackend({ primary });
+      // a bare sentinel (not a real stream) proves no `.pipe()`/tee was attempted
+      const sentinelStream = {};
+      const result = await mirror.putStream('key', sentinelStream, { contentType: 'text/plain' });
+      assert.strictEqual(result.value, 'S3-value');
+      assert.strictEqual(primary.calls.putStream, 1);
+    });
+
+    it('tees the stream to every backend, each receiving the full body', async () => {
+      const primary = new FakeBackend('S3', { consumeStream: true });
+      const r2 = new FakeBackend('R2', { consumeStream: true });
+      const azure = new FakeBackend('Azure', { consumeStream: true });
+      const mirror = new MirroringBackend({ primary, secondaries: [r2, azure] });
+      const source = Readable.from([Buffer.from('hello world')]);
+
+      const result = await mirror.putStream('key', source, {});
+      assert.strictEqual(result.value, 'S3-value');
+      [primary, r2, azure].forEach((backend) => {
+        assert.strictEqual(backend.calls.putStream, 1);
+        assert.strictEqual(backend.received.toString(), 'hello world');
+      });
+    });
+
+    it('propagates a source stream error to every tee', async () => {
+      const primary = new FakeBackend('S3', { consumeStream: true });
+      const secondary = new FakeBackend('R2', { consumeStream: true });
+      const mirror = new MirroringBackend({ primary, secondaries: [secondary] });
+      const source = new PassThrough();
+
+      const promise = mirror.putStream('key', source, {});
+      source.destroy(new Error('source read failed'));
+
+      await assert.rejects(promise, (err) => {
+        assert.strictEqual(err.message, '[S3] source read failed');
+        return true;
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes the remaining gap identified in adobe/helix-shared#1258 / adobe/helix-mediahandler#441: every `StorageBackend`'s `put()` requires a fully buffered `Buffer|string` body with a known length (`S3Backend.put()` uses a single `PutObjectCommand`; `AzureBackend.put()` calls `blockBlobClient.upload(data, data.length, ...)`), which is fine for content-bus/code-bus (small, compressible text) but blocks a future media-bus migration (`helix-mediahandler`) — media needs to stream large, already-compressed binary uploads via multipart, without gzip.

- Adds `putStream(key, stream, opts)` to the `StorageBackend` interface (`AbstractStorageBackend.js`), with a generic default that buffers the stream fully then delegates to `put()` — works for any backend without extra work, overridable for real chunked/multipart streaming.
- `S3Backend.putStream()` overrides it using `@aws-sdk/lib-storage`'s `Upload` helper, which transparently switches to multipart for large streams (new dependency on `@adobe/helix-shared-storage-s3`).
- `AzureBackend.putStream()` overrides it using `BlockBlobClient.uploadStream()` (staged-block + commit-block-list under the hood — verified via a live probe against the real SDK, since it always uses this path regardless of size, unlike S3's size-based fallback).
- `MirroringBackend.putStream()` tees the source stream into one `PassThrough` per backend when there are 2+ backends (single backend streams directly, no tee), forwarding a source-stream read error to every tee so a broken source aborts all in-flight uploads instead of hanging. The existing `_fanOut(method, args)` fan-out helper was refactored into a lower-level `_fanOutCalls(calls)` (array of per-backend thunks) so both the uniform-args case and the per-backend-tee case share one error-tagging implementation.
- `Bucket.putStream(path, stream, contentType, meta)` is a thin facade wrapper, deliberately with no `compress` parameter — compressing a streamed upload isn't supported, so the signature makes that explicit rather than a runtime check.

`put()` itself is untouched everywhere; this is purely additive.

## Test plan

- [x] `npx nx run-many -t test,lint` passes for all 18 workspace projects.
- [x] `@adobe/helix-shared-storage`, `@adobe/helix-shared-storage-s3`, and `@adobe/helix-shared-storage-azure` all retain 100% line/branch/function/statement coverage.
- [x] New `MirroringBackend` tests cover: single-backend passthrough (no tee), N-backend tee (each backend receives the full body), and source-stream error propagation to every tee.
- [x] New `S3Backend` test exercises `putStream()` through a real `Upload` instance against nock (small body → falls back to a single `PutObject`, matching `helix-mediahandler`'s existing production behavior for its typical fixture sizes).
- [x] New `AzureBackend` test exercises `putStream()` against nock's staged-block (`comp=block`) + commit-block-list (`comp=blocklist`) endpoints, confirmed against the real `@azure/storage-blob` SDK's actual wire behavior before writing the mock.
- [x] Confirmed zero cloud-SDK footprint in core: `grep -rn "@aws-sdk\|@azure" packages/helix-shared-storage/package.json packages/helix-shared-storage/src` only matches a JSDoc comment mentioning the SDK names in prose, not an actual dependency/import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)