### PR TITLE
feat(storage): add a common StorageError class shared by S3Backend and AzureBackend

### DIFF
--- a/packages/helix-shared-storage-azure/src/AzureBackend.js
+++ b/packages/helix-shared-storage-azure/src/AzureBackend.js
@@ -189,11 +189,7 @@ export class AzureBackend extends AbstractStorageBackend {
       }
       return buf;
     } catch (e) {
-      /* c8 ignore next 3 */
-      if (e.statusCode !== 404) {
-        throw e;
-      }
-      return null;
+      return this._wrapOr404(e, e.message, { status: e.statusCode, code: e.code });
     }
   }
 
@@ -217,11 +213,7 @@ export class AzureBackend extends AbstractStorageBackend {
         raw,
       };
     } catch (e) {
-      /* c8 ignore next 3 */
-      if (e.statusCode !== 404) {
-        throw e;
-      }
-      return null;
+      return this._wrapOr404(e, e.message, { status: e.statusCode, code: e.code });
     }
   }
 
@@ -234,14 +226,18 @@ export class AzureBackend extends AbstractStorageBackend {
   async put(key, body, opts = {}) {
     const data = typeof body === 'string' ? Buffer.from(body) : body;
     const blockBlobClient = this._client.getBlockBlobClient(key);
-    const raw = await blockBlobClient.upload(data, data.length, {
-      blobHTTPHeaders: buildBlobHTTPHeaders(opts),
-      metadata: toAzureMetadata(opts.metadata),
-    });
-    this._log.info(`object uploaded to: ${this._bucketName}/${key}`);
-    return {
-      etag: raw.etag, contentType: opts.contentType, raw,
-    };
+    try {
+      const raw = await blockBlobClient.upload(data, data.length, {
+        blobHTTPHeaders: buildBlobHTTPHeaders(opts),
+        metadata: toAzureMetadata(opts.metadata),
+      });
+      this._log.info(`object uploaded to: ${this._bucketName}/${key}`);
+      return {
+        etag: raw.etag, contentType: opts.contentType, raw,
+      };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.statusCode, code: e.code });
+    }
   }
 
   /**
@@ -256,14 +252,18 @@ export class AzureBackend extends AbstractStorageBackend {
    */
   async putStream(key, body, opts = {}) {
     const blockBlobClient = this._client.getBlockBlobClient(key);
-    const raw = await blockBlobClient.uploadStream(body, undefined, undefined, {
-      blobHTTPHeaders: buildBlobHTTPHeaders(opts),
-      metadata: toAzureMetadata(opts.metadata),
-    });
-    this._log.info(`object uploaded to: ${this._bucketName}/${key}`);
-    return {
-      etag: raw.etag, contentType: opts.contentType, raw,
-    };
+    try {
+      const raw = await blockBlobClient.uploadStream(body, undefined, undefined, {
+        blobHTTPHeaders: buildBlobHTTPHeaders(opts),
+        metadata: toAzureMetadata(opts.metadata),
+      });
+      this._log.info(`object uploaded to: ${this._bucketName}/${key}`);
+      return {
+        etag: raw.etag, contentType: opts.contentType, raw,
+      };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.statusCode, code: e.code });
+    }
   }
 
   /**
@@ -289,12 +289,16 @@ export class AzureBackend extends AbstractStorageBackend {
         customMetadata[key] = value;
       }
     });
-    const [metadataRaw, headersRaw] = await Promise.all([
-      blobClient.setMetadata(toAzureMetadata(customMetadata)),
-      blobClient.setHTTPHeaders(blobHTTPHeaders),
-    ]);
-    this._log.info(`Metadata updated for: ${this._bucketName}/${path}`);
-    return { raw: { metadata: metadataRaw, headers: headersRaw } };
+    try {
+      const [metadataRaw, headersRaw] = await Promise.all([
+        blobClient.setMetadata(toAzureMetadata(customMetadata)),
+        blobClient.setHTTPHeaders(blobHTTPHeaders),
+      ]);
+      this._log.info(`Metadata updated for: ${this._bucketName}/${path}`);
+      return { raw: { metadata: metadataRaw, headers: headersRaw } };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.statusCode, code: e.code });
+    }
   }
 
   /**
@@ -349,16 +353,13 @@ export class AzureBackend extends AbstractStorageBackend {
       return { etag: raw.etag, raw };
     } catch (e) {
       if (e.statusCode === 404) {
-        const e2 = new Error(`source does not exist: ${this._bucketName}/${src}`);
-        e2.status = 404;
-        throw e2;
+        throw this._wrapError(e, `source does not exist: ${this._bucketName}/${src}`, { status: 404, code: e.code });
       }
       // Normalize the native error's HTTP status onto `.status`, same convention as the 404
       // case above, so callers (e.g. optimistic-concurrency retry logic keying off a failed
       // `ifMatch`/`ifNoneMatch`/`sourceIfMatch` precondition) can branch on it without knowing
       // this is an Azure SDK error shape.
-      e.status = e.statusCode;
-      throw e;
+      throw this._wrapError(e, e.message, { status: e.statusCode, code: e.code });
     }
   }
 
@@ -385,9 +386,7 @@ export class AzureBackend extends AbstractStorageBackend {
           if (stopOnError) {
             const msg = `removing ${key} from bucket ${bucket} failed: ${e.message}`;
             log.error(msg);
-            const e2 = new Error(msg);
-            e2.status = e.statusCode;
-            throw e2;
+            throw this._wrapError(e, msg, { status: e.statusCode, code: e.code });
           }
         }
       }, REMOVE_CONCURRENCY);
@@ -402,9 +401,7 @@ export class AzureBackend extends AbstractStorageBackend {
     } catch (e) {
       const msg = `removing ${bucket}/${pathOrPaths} from storage failed: ${e.message}`;
       log.error(msg);
-      const e2 = new Error(msg);
-      e2.status = e.statusCode;
-      throw e2;
+      throw this._wrapError(e, msg, { status: e.statusCode, code: e.code });
     }
   }
 
@@ -417,28 +414,32 @@ export class AzureBackend extends AbstractStorageBackend {
     const { shallow = false, maxItems = Number.POSITIVE_INFINITY } = opts;
 
     const objects = [];
-    const iter = shallow
-      ? this._client.listBlobsByHierarchy('/', { prefix })
-      : this._client.listBlobsFlat({ prefix });
-    // eslint-disable-next-line no-restricted-syntax
-    for await (const item of iter) {
-      if (objects.length >= maxItems) {
-        break;
+    try {
+      const iter = shallow
+        ? this._client.listBlobsByHierarchy('/', { prefix })
+        : this._client.listBlobsFlat({ prefix });
+      // eslint-disable-next-line no-restricted-syntax
+      for await (const item of iter) {
+        if (objects.length >= maxItems) {
+          break;
+        }
+        if (item.kind === 'prefix') {
+          objects.push({ key: item.name, name: basename(item.name), isFolder: true });
+        } else {
+          objects.push({
+            key: item.name,
+            name: basename(item.name),
+            isFolder: item.name.endsWith('/'),
+            lastModified: item.properties.lastModified,
+            contentLength: item.properties.contentLength,
+            contentType: item.properties.contentType,
+          });
+        }
       }
-      if (item.kind === 'prefix') {
-        objects.push({ key: item.name, name: basename(item.name), isFolder: true });
-      } else {
-        objects.push({
-          key: item.name,
-          name: basename(item.name),
-          isFolder: item.name.endsWith('/'),
-          lastModified: item.properties.lastModified,
-          contentLength: item.properties.contentLength,
-          contentType: item.properties.contentType,
-        });
-      }
+      return { prefix, objects, continuationToken: undefined };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.statusCode, code: e.code });
     }
-    return { prefix, objects, continuationToken: undefined };
   }
 
   /**
@@ -449,30 +450,34 @@ export class AzureBackend extends AbstractStorageBackend {
   async browse(prefix, opts = {}) {
     const { continuationToken, maxItems } = opts;
 
-    const iter = this._client
-      .listBlobsByHierarchy('/', { prefix })
-      .byPage({ continuationToken, maxPageSize: maxItems });
-    const { value } = await iter.next();
+    try {
+      const iter = this._client
+        .listBlobsByHierarchy('/', { prefix })
+        .byPage({ continuationToken, maxPageSize: maxItems });
+      const { value } = await iter.next();
 
-    const objects = [];
-    value.segment.blobPrefixes.forEach(({ name }) => {
-      objects.push({ key: name, name: basename(name), isFolder: true });
-    });
-    value.segment.blobItems.forEach((item) => {
-      objects.push({
-        key: item.name,
-        name: basename(item.name),
-        isFolder: false,
-        lastModified: item.properties.lastModified,
-        contentLength: item.properties.contentLength,
-        contentType: item.properties.contentType,
+      const objects = [];
+      value.segment.blobPrefixes.forEach(({ name }) => {
+        objects.push({ key: name, name: basename(name), isFolder: true });
       });
-    });
+      value.segment.blobItems.forEach((item) => {
+        objects.push({
+          key: item.name,
+          name: basename(item.name),
+          isFolder: false,
+          lastModified: item.properties.lastModified,
+          contentLength: item.properties.contentLength,
+          contentType: item.properties.contentType,
+        });
+      });
 
-    return {
-      prefix,
-      objects,
-      continuationToken: value.continuationToken || undefined,
-    };
+      return {
+        prefix,
+        objects,
+        continuationToken: value.continuationToken || undefined,
+      };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.statusCode, code: e.code });
+    }
   }
 }

--- a/packages/helix-shared-storage-azure/test/storage.test.js
+++ b/packages/helix-shared-storage-azure/test/storage.test.js
@@ -16,7 +16,7 @@ import { Readable } from 'node:stream';
 import { promisify } from 'util';
 import zlib from 'zlib';
 import { BlobServiceClient, StorageSharedKeyCredential } from '@azure/storage-blob';
-import { Storage } from '@adobe/helix-shared-storage';
+import { Storage, StorageError } from '@adobe/helix-shared-storage';
 import { Nock } from './utils.js';
 import { StorageAzure } from '../src/StorageAzure.js';
 import { AzureBackend } from '../src/AzureBackend.js';
@@ -180,7 +180,14 @@ describe('AzureBackend storage test', () => {
       .reply(500, '<?xml version="1.0" encoding="utf-8"?><Error><Code>InternalError</Code></Error>', {
         'content-type': 'application/xml',
       });
-    await assert.rejects(backend.get('foo'));
+    await assert.rejects(backend.get('foo'), (e) => {
+      assert.ok(e instanceof StorageError);
+      assert.strictEqual(e.status, 500);
+      assert.strictEqual(e.code, 'InternalError');
+      assert.strictEqual(e.backend, 'Azure');
+      assert.ok(e.cause);
+      return true;
+    });
   });
 
   it('can get metadata of an object', async () => {
@@ -515,5 +522,80 @@ describe('AzureBackend storage test', () => {
       }), { 'content-type': 'application/xml' });
     const { continuationToken } = await backend.browse('foo/');
     assert.strictEqual(continuationToken, undefined);
+  });
+
+  describe('error normalization', () => {
+    it('putStream() throws a StorageError on SDK failure', async () => {
+      nock(BASE_URL)
+        .put((uri) => uri.startsWith('/helix-code-bus/foo?comp=block&blockid='))
+        .reply(500);
+      const stream = Readable.from([Buffer.from('hello, world.')]);
+      await assert.rejects(backend.putStream('foo', stream, { contentType: 'text/plain' }), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'Azure');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
+
+    it('put() throws a StorageError on SDK failure', async () => {
+      nock(BASE_URL)
+        .put('/helix-code-bus/foo')
+        .reply(500);
+      await assert.rejects(backend.put('foo', 'hello, world.'), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'Azure');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
+
+    it('putMeta() throws a StorageError on SDK failure', async () => {
+      nock(BASE_URL)
+        .put('/helix-code-bus/foo')
+        .query({ comp: 'metadata' })
+        .reply(500);
+      nock(BASE_URL)
+        .put('/helix-code-bus/foo')
+        .query({ comp: 'properties' })
+        .reply(200, '', { etag: '"abc"' });
+      await assert.rejects(backend.putMeta('foo', { 'source-location': 'new-location' }), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'Azure');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
+
+    it('list() throws a StorageError on SDK failure', async () => {
+      nock(BASE_URL)
+        .get('/helix-code-bus')
+        .query((q) => q.restype === 'container' && q.comp === 'list')
+        .reply(500);
+      await assert.rejects(backend.list('foo/'), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'Azure');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
+
+    it('browse() throws a StorageError on SDK failure', async () => {
+      nock(BASE_URL)
+        .get('/helix-code-bus')
+        .query((q) => q.restype === 'container' && q.comp === 'list' && q.delimiter === '/')
+        .reply(500);
+      await assert.rejects(backend.browse('foo/'), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'Azure');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
   });
 });

--- a/packages/helix-shared-storage-s3/src/S3Backend.js
+++ b/packages/helix-shared-storage-s3/src/S3Backend.js
@@ -184,11 +184,7 @@ export class S3Backend extends AbstractStorageBackend {
       }
       return buf;
     } catch (e) {
-      /* c8 ignore next 3 */
-      if (e.$metadata.httpStatusCode !== 404) {
-        throw e;
-      }
-      return null;
+      return this._wrapOr404(e, e.message, { status: e.$metadata?.httpStatusCode, code: e.Code });
     }
   }
 
@@ -215,11 +211,7 @@ export class S3Backend extends AbstractStorageBackend {
       });
       return result;
     } catch (e) {
-      /* c8 ignore next 3 */
-      if (e.$metadata.httpStatusCode !== 404) {
-        throw e;
-      }
-      return null;
+      return this._wrapOr404(e, e.message, { status: e.$metadata?.httpStatusCode, code: e.Code });
     }
   }
 
@@ -252,11 +244,15 @@ export class S3Backend extends AbstractStorageBackend {
    */
   async put(key, body, opts = {}) {
     const input = this._buildPutInput(key, body, opts);
-    const raw = await this._client.send(new PutObjectCommand(input));
-    this._log.info(`object uploaded to: ${input.Bucket}/${input.Key}`);
-    return {
-      etag: raw.ETag, versionId: raw.VersionId, contentType: opts.contentType, raw,
-    };
+    try {
+      const raw = await this._client.send(new PutObjectCommand(input));
+      this._log.info(`object uploaded to: ${input.Bucket}/${input.Key}`);
+      return {
+        etag: raw.ETag, versionId: raw.VersionId, contentType: opts.contentType, raw,
+      };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.$metadata?.httpStatusCode, code: e.Code });
+    }
   }
 
   /**
@@ -270,12 +266,16 @@ export class S3Backend extends AbstractStorageBackend {
    */
   async putStream(key, body, opts = {}) {
     const input = this._buildPutInput(key, body, opts);
-    const upload = new Upload({ client: this._client, params: input });
-    const raw = await upload.done();
-    this._log.info(`object uploaded to: ${input.Bucket}/${input.Key}`);
-    return {
-      etag: raw.ETag, versionId: raw.VersionId, contentType: opts.contentType, raw,
-    };
+    try {
+      const upload = new Upload({ client: this._client, params: input });
+      const raw = await upload.done();
+      this._log.info(`object uploaded to: ${input.Bucket}/${input.Key}`);
+      return {
+        etag: raw.ETag, versionId: raw.VersionId, contentType: opts.contentType, raw,
+      };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.$metadata?.httpStatusCode, code: e.Code });
+    }
   }
 
   /**
@@ -305,9 +305,13 @@ export class S3Backend extends AbstractStorageBackend {
         input.Metadata[key] = value;
       }
     });
-    const raw = await this._client.send(new CopyObjectCommand(input));
-    this._log.info(`Metadata updated for: ${input.CopySource}`);
-    return { raw };
+    try {
+      const raw = await this._client.send(new CopyObjectCommand(input));
+      this._log.info(`Metadata updated for: ${input.CopySource}`);
+      return { raw };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.$metadata?.httpStatusCode, code: e.Code });
+    }
   }
 
   /**
@@ -363,16 +367,13 @@ export class S3Backend extends AbstractStorageBackend {
     } catch (e) {
       const status = e.$metadata?.httpStatusCode;
       if (e.Code === 'NoSuchKey' || status === 404) {
-        const e2 = new Error(`source does not exist: ${input.CopySource}`);
-        e2.status = 404;
-        throw e2;
+        throw this._wrapError(e, `source does not exist: ${input.CopySource}`, { status: 404, code: e.Code });
       }
       // Normalize the native error's HTTP status onto `.status`, same convention as the 404
       // case above, so callers (e.g. optimistic-concurrency retry logic keying off a failed
       // `ifMatch`/`ifNoneMatch`/`sourceIfMatch` precondition) can branch on it without knowing
       // this is an AWS SDK error shape.
-      e.status = status;
-      throw e;
+      throw this._wrapError(e, e.message, { status, code: e.Code });
     }
   }
 
@@ -422,14 +423,12 @@ export class S3Backend extends AbstractStorageBackend {
             errors += res.Errors.length;
           }
         } catch (e) {
-          log.warn(`error while deleting ${chunk.length} from ${bucket}/${sourceInfo}: ${e.message} (${e.$metadata.httpStatusCode})`);
+          log.warn(`error while deleting ${chunk.length} from ${bucket}/${sourceInfo}: ${e.message} (${e.$metadata?.httpStatusCode})`);
           errors += chunk.length;
           if (stopOnError) {
             const msg = `removing ${input.Delete.Objects.length} objects from bucket ${input.Bucket} failed: ${e.message}`;
             log.error(msg);
-            const e2 = new Error(msg);
-            e2.status = e.$metadata.httpStatusCode;
-            throw e2;
+            throw this._wrapError(e, msg, { status: e.$metadata?.httpStatusCode, code: e.Code });
           }
         }
       }, 2);
@@ -449,12 +448,10 @@ export class S3Backend extends AbstractStorageBackend {
       const msg = `removing ${bucket}/${input.Key} from storage failed: ${e.message}`;
       log.error(msg);
 
-      const e2 = /Deserialization error: to see the raw response, inspect the hidden field \{error\}\.\$response/.test(e.message)
-        ? new Error(e.$response.body)
-        : new Error(msg);
+      const isDeserializationError = /Deserialization error: to see the raw response, inspect the hidden field \{error\}\.\$response/.test(e.message);
+      const message = isDeserializationError ? e.$response.body : msg;
 
-      e2.status = e.$metadata.httpStatusCode;
-      throw e2;
+      throw this._wrapError(e, message, { status: e.$metadata?.httpStatusCode, code: e.Code });
     }
   }
 
@@ -468,22 +465,26 @@ export class S3Backend extends AbstractStorageBackend {
 
     let ContinuationToken;
     const objects = [];
-    do {
-      const input = {
-        Bucket: this._bucketName,
-        ContinuationToken,
-        Prefix: prefix,
-        Delimiter: shallow ? '/' : undefined,
-      };
-      if (maxItems - objects.length < 1000) {
-        input.MaxKeys = maxItems - objects.length;
-      }
-      // eslint-disable-next-line no-await-in-loop
-      const result = await this._client.send(new ListObjectsV2Command(input));
-      ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
-      objects.push(...listResultToObjectInfos(result));
-    } while (ContinuationToken && objects.length < maxItems);
-    return { prefix, objects, continuationToken: undefined };
+    try {
+      do {
+        const input = {
+          Bucket: this._bucketName,
+          ContinuationToken,
+          Prefix: prefix,
+          Delimiter: shallow ? '/' : undefined,
+        };
+        if (maxItems - objects.length < 1000) {
+          input.MaxKeys = maxItems - objects.length;
+        }
+        // eslint-disable-next-line no-await-in-loop
+        const result = await this._client.send(new ListObjectsV2Command(input));
+        ContinuationToken = result.IsTruncated ? result.NextContinuationToken : '';
+        objects.push(...listResultToObjectInfos(result));
+      } while (ContinuationToken && objects.length < maxItems);
+      return { prefix, objects, continuationToken: undefined };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.$metadata?.httpStatusCode, code: e.Code });
+    }
   }
 
   /**
@@ -494,20 +495,24 @@ export class S3Backend extends AbstractStorageBackend {
   async browse(prefix, opts = {}) {
     const { continuationToken, maxItems } = opts;
 
-    const result = await this._client.send(new ListObjectsV2Command({
-      Bucket: this._bucketName,
-      Prefix: prefix,
-      Delimiter: '/',
-      ContinuationToken: continuationToken || undefined,
-      MaxKeys: maxItems,
-    }));
+    try {
+      const result = await this._client.send(new ListObjectsV2Command({
+        Bucket: this._bucketName,
+        Prefix: prefix,
+        Delimiter: '/',
+        ContinuationToken: continuationToken || undefined,
+        MaxKeys: maxItems,
+      }));
 
-    return {
-      prefix,
-      objects: listResultToObjectInfos(result),
-      continuationToken: result.IsTruncated
-        ? result.NextContinuationToken
-        : undefined,
-    };
+      return {
+        prefix,
+        objects: listResultToObjectInfos(result),
+        continuationToken: result.IsTruncated
+          ? result.NextContinuationToken
+          : undefined,
+      };
+    } catch (e) {
+      throw this._wrapError(e, e.message, { status: e.$metadata?.httpStatusCode, code: e.Code });
+    }
   }
 }

--- a/packages/helix-shared-storage-s3/test/storage.test.js
+++ b/packages/helix-shared-storage-s3/test/storage.test.js
@@ -22,7 +22,7 @@ import xml2js from 'xml2js';
 import zlib from 'zlib';
 import { S3Client } from '@aws-sdk/client-s3';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-import { Storage, MirroringBackend } from '@adobe/helix-shared-storage';
+import { Storage, MirroringBackend, StorageError } from '@adobe/helix-shared-storage';
 import { Nock } from './utils.js';
 import { StorageS3 } from '../src/StorageS3.js';
 import { S3Backend } from '../src/S3Backend.js';
@@ -213,9 +213,13 @@ describe('Storage test', () => {
       .get('/foo?x-id=GetObject')
       .reply(401);
     const bus = storage.codeBus();
-    const error = Error('UnknownError');
-    error.name = 'Unknown';
-    await assert.rejects(bus.get('/foo'), error);
+    await assert.rejects(bus.get('/foo'), (e) => {
+      assert.ok(e instanceof StorageError);
+      assert.strictEqual(e.message, 'UnknownError');
+      assert.strictEqual(e.status, 401);
+      assert.strictEqual(e.backend, 'S3');
+      return true;
+    });
   });
 
   it('can get metadata of an object', async () => {
@@ -602,8 +606,6 @@ describe('Storage test', () => {
     // (previously it was the other way around, and the tag was incidentally lost when the
     // deserialization-error branch reconstructed the error from the raw response body).
     const rawBody = 'this is not an XML error';
-    const expected = new Error(`[R2] ${rawBody}`);
-    expected.status = 500;
 
     nock('https://helix-code-bus.s3.fake.amazonaws.com')
       .delete('/foo?x-id=DeleteObject')
@@ -614,10 +616,15 @@ describe('Storage test', () => {
 
     nock(`https://helix-code-bus.${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`)
       .delete('/foo?x-id=DeleteObject')
-      .reply(expected.status, rawBody);
+      .reply(500, rawBody);
 
     const bus = storage.codeBus();
-    await assert.rejects(async () => bus.remove('/foo'), expected);
+    await assert.rejects(async () => bus.remove('/foo'), (e) => {
+      assert.ok(e instanceof StorageError);
+      assert.strictEqual(e.message, `[R2] ${rawBody}`);
+      assert.strictEqual(e.status, 500);
+      return true;
+    });
   });
 
   it('can remove objects', async () => {
@@ -1248,7 +1255,9 @@ describe('Storage test', () => {
       .reply(200, body);
     const bus = storage.codeBus();
     await assert.rejects(bus.copy('/owner/repo/ref/foo.md', '/owner/repo/ref/foo/bar.md'), (e) => {
+      assert.ok(e instanceof StorageError);
       assert.strictEqual(e.status, 404);
+      assert.strictEqual(e.code, 'NoSuchKey');
       assert.match(e.message, /source does not exist/);
       return true;
     });
@@ -1883,6 +1892,94 @@ describe('Storage test', () => {
     const changes = await bus.copyDeep('src/', '');
     assert.strictEqual(changes.length, 1);
     assert.strictEqual(changes[0].dst, 'foo.txt');
+  });
+
+  describe('error normalization', () => {
+    it('putStream() throws a StorageError on SDK failure', async () => {
+      nock('https://helix-code-bus.s3.fake.amazonaws.com')
+        .put('/foo?x-id=PutObject')
+        .reply(500);
+
+      const bus = storage.codeBus({ disableR2: true });
+      const stream = Readable.from([Buffer.from('hello, world.')]);
+      await assert.rejects(bus.putStream('/foo', stream), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'S3');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
+
+    it('put() throws a StorageError on SDK failure', async () => {
+      nock('https://helix-code-bus.s3.fake.amazonaws.com')
+        .put('/foo?x-id=PutObject')
+        .reply(500);
+
+      const bus = storage.codeBus({ disableR2: true });
+      await assert.rejects(bus.put('/foo', 'hello, world.'), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'S3');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
+
+    it('putMeta() throws a StorageError on SDK failure', async () => {
+      nock('https://helix-code-bus.s3.fake.amazonaws.com')
+        .put('/owner/repo/ref?x-id=CopyObject')
+        .reply(500);
+
+      const bus = storage.codeBus({ disableR2: true });
+      await assert.rejects(bus.putMeta('/owner/repo/ref', { 'source-location': 'new-location' }), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'S3');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
+
+    it('list() throws a StorageError on SDK failure', async () => {
+      nock('https://helix-code-bus.s3.fake.amazonaws.com')
+        .get('/')
+        .query({
+          delimiter: '/',
+          'list-type': 2,
+          prefix: 'owner/repo/ref/',
+        })
+        .reply(500);
+
+      const bus = storage.codeBus({ disableR2: true });
+      await assert.rejects(bus.list('owner/repo/ref/', { shallow: true }), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'S3');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
+
+    it('browse() throws a StorageError on SDK failure', async () => {
+      nock('https://helix-code-bus.s3.fake.amazonaws.com')
+        .get('/')
+        .query({
+          delimiter: '/',
+          'list-type': 2,
+          prefix: '',
+        })
+        .reply(500);
+
+      const bus = storage.codeBus({ disableR2: true });
+      await assert.rejects(bus.browse(''), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        assert.strictEqual(e.backend, 'S3');
+        assert.ok(e.cause);
+        return true;
+      });
+    });
   });
 });
 

--- a/packages/helix-shared-storage/src/AbstractStorageBackend.js
+++ b/packages/helix-shared-storage/src/AbstractStorageBackend.js
@@ -11,6 +11,7 @@
  */
 
 import { buffer } from 'node:stream/consumers';
+import { StorageError } from './StorageError.js';
 
 /**
  * Common, backend-agnostic object metadata fields (lowerCamelCase). Every {@link StorageBackend}
@@ -200,6 +201,52 @@ export const SYSTEM_META_FIELD_NAMES = [
  * @implements {StorageBackend}
  */
 export class AbstractStorageBackend {
+  /**
+   * Wraps a caught, backend-native SDK error into a {@link StorageError} tagged with this
+   * backend's `name`. Passes an already-`StorageError` through unchanged instead of
+   * double-wrapping it (e.g. one that bubbled up through a generic-default method's inner
+   * call to another mandatory primitive on `this`, such as `getMeta()`'s call to `head()`).
+   *
+   * @protected
+   * @param {Error} e the raw, caught SDK error
+   * @param {string} message normalized message for the new `StorageError` — callers without a
+   *  better message should pass `e.message` through verbatim
+   * @param {Object} [fields]
+   * @param {number} [fields.status]
+   * @param {string} [fields.code]
+   * @returns {StorageError}
+   */
+  _wrapError(e, message, { status, code } = {}) {
+    if (e instanceof StorageError) {
+      return e;
+    }
+    return new StorageError(message, {
+      status, code, backend: this.name, cause: e,
+    });
+  }
+
+  /**
+   * Shared helper for `get()`/`head()`'s "swallow 404 into `null`" convention: wraps `e` via
+   * {@link AbstractStorageBackend#_wrapError} and, if its normalized `status` is `404`,
+   * returns `null` instead of throwing.
+   *
+   * @protected
+   * @param {Error} e the raw, caught SDK error
+   * @param {string} message
+   * @param {Object} [fields]
+   * @param {number} [fields.status]
+   * @param {string} [fields.code]
+   * @returns {null}
+   * @throws {StorageError} when `status` is not `404`
+   */
+  _wrapOr404(e, message, fields = {}) {
+    const wrapped = this._wrapError(e, message, fields);
+    if (wrapped.status === 404) {
+      return null;
+    }
+    throw wrapped;
+  }
+
   async get() {
     throw new Error('get() not implemented');
   }

--- a/packages/helix-shared-storage/src/StorageError.js
+++ b/packages/helix-shared-storage/src/StorageError.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Normalized error thrown by {@link StorageBackend} implementations for any failure that
+ * originates from the underlying cloud SDK (S3, Azure, ...). Every backend wraps its
+ * SDK-native error (AWS's `$metadata.httpStatusCode`/`Code`, Azure's `statusCode`/`code`, ...)
+ * into one of these before throwing, so callers (e.g. {@link Bucket}, {@link MirroringBackend},
+ * or application code built on `StorageBackend`) can branch on `.status`/`.code` without
+ * knowing which backend they're talking to. The original, raw SDK error is always preserved,
+ * unmodified, as `.cause`.
+ *
+ * @property {number} [status] normalized HTTP status code (e.g. `404`, `412`, `500`)
+ * @property {string} [code] backend-specific error code, verbatim, when the backend's SDK
+ *  exposes one (e.g. S3's `NoSuchKey`, Azure's `BlobNotFound`)
+ * @property {string} [backend] the originating backend's `name` (e.g. `'S3'`, `'R2'`,
+ *  `'Azure'`) — the same tag {@link MirroringBackend} uses to prefix `.message` on fan-out
+ *  failures
+ * @property {Error} [cause] the original, raw, backend-native SDK error, unmodified
+ */
+export class StorageError extends Error {
+  /**
+   * @param {string} message
+   * @param {Object} [opts]
+   * @param {number} [opts.status]
+   * @param {string} [opts.code]
+   * @param {string} [opts.backend]
+   * @param {Error} [opts.cause] passed through to the standard `Error` `cause` option
+   */
+  constructor(message, {
+    status, code, backend, cause,
+  } = {}) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = 'StorageError';
+    this.status = status;
+    this.code = code;
+    this.backend = backend;
+  }
+}

--- a/packages/helix-shared-storage/src/index.js
+++ b/packages/helix-shared-storage/src/index.js
@@ -13,3 +13,4 @@ export { parseBucketNames, resolveMetadataForCopy, Storage } from './storage.js'
 export { Bucket } from './Bucket.js';
 export { MirroringBackend } from './MirroringBackend.js';
 export { AbstractStorageBackend, SYSTEM_META_FIELD_NAMES } from './AbstractStorageBackend.js';
+export { StorageError } from './StorageError.js';

--- a/packages/helix-shared-storage/test/AbstractStorageBackend.test.js
+++ b/packages/helix-shared-storage/test/AbstractStorageBackend.test.js
@@ -14,12 +14,18 @@
 import assert from 'assert';
 import { Readable } from 'node:stream';
 import { AbstractStorageBackend } from '../src/AbstractStorageBackend.js';
+import { StorageError } from '../src/StorageError.js';
 
 class MinimalBackend extends AbstractStorageBackend {
   constructor(heads = {}, listResult = { prefix: '', objects: [], continuationToken: undefined }) {
     super();
     this._heads = heads;
     this._listResult = listResult;
+  }
+
+  // eslint-disable-next-line class-methods-use-this -- fixed tag, like real backends' `name`
+  get name() {
+    return 'Minimal';
   }
 
   async head(key) {
@@ -99,6 +105,49 @@ describe('AbstractStorageBackend', () => {
       assert.strictEqual(backend.putCall.key, 'foo');
       assert.strictEqual(backend.putCall.body.toString(), 'hello world');
       assert.strictEqual(backend.putCall.opts, opts);
+    });
+  });
+
+  describe('_wrapError()/_wrapOr404()', () => {
+    it('_wrapError() wraps a raw error into a StorageError tagged with this.name', () => {
+      const backend = new MinimalBackend();
+      const raw = new Error('boom');
+      // eslint-disable-next-line no-underscore-dangle -- exercising the protected helper directly
+      const wrapped = backend._wrapError(raw, 'wrapped msg', { status: 500, code: 'X' });
+      assert.ok(wrapped instanceof StorageError);
+      assert.strictEqual(wrapped.message, 'wrapped msg');
+      assert.strictEqual(wrapped.status, 500);
+      assert.strictEqual(wrapped.code, 'X');
+      assert.strictEqual(wrapped.backend, 'Minimal');
+      assert.strictEqual(wrapped.cause, raw);
+    });
+
+    it('_wrapError() passes an already-StorageError through unchanged', () => {
+      const backend = new MinimalBackend();
+      const original = new StorageError('original msg', { status: 404, backend: 'Other' });
+      // eslint-disable-next-line no-underscore-dangle -- exercising the protected helper directly
+      const result = backend._wrapError(original, 'other msg', { status: 500 });
+      assert.strictEqual(result, original);
+      assert.strictEqual(result.message, 'original msg');
+      assert.strictEqual(result.status, 404);
+      assert.strictEqual(result.backend, 'Other');
+    });
+
+    it('_wrapOr404() returns null when the normalized status is 404', () => {
+      const backend = new MinimalBackend();
+      // eslint-disable-next-line no-underscore-dangle -- exercising the protected helper directly
+      const result = backend._wrapOr404(new Error('not found'), 'not found', { status: 404 });
+      assert.strictEqual(result, null);
+    });
+
+    it('_wrapOr404() throws a StorageError when the normalized status is not 404', () => {
+      const backend = new MinimalBackend();
+      // eslint-disable-next-line no-underscore-dangle -- exercising the protected helper directly
+      assert.throws(() => backend._wrapOr404(new Error('boom'), 'boom', { status: 500 }), (e) => {
+        assert.ok(e instanceof StorageError);
+        assert.strictEqual(e.status, 500);
+        return true;
+      });
     });
   });
 

--- a/packages/helix-shared-storage/test/MirroringBackend.test.js
+++ b/packages/helix-shared-storage/test/MirroringBackend.test.js
@@ -15,6 +15,7 @@ import assert from 'assert';
 import { PassThrough, Readable } from 'node:stream';
 import { buffer as readStreamBuffer } from 'node:stream/consumers';
 import { MirroringBackend } from '../src/MirroringBackend.js';
+import { StorageError } from '../src/StorageError.js';
 
 /**
  * Minimal fake backend: records calls, either resolves with a fixed value or rejects with a
@@ -22,19 +23,23 @@ import { MirroringBackend } from '../src/MirroringBackend.js';
  */
 class FakeBackend {
   constructor(name, {
-    fails = false, value = `${name}-value`, client = `${name}-client`, consumeStream = false,
+    fails = false, throwError = null, value = `${name}-value`, client = `${name}-client`, consumeStream = false,
   } = {}) {
     this.name = name;
     this.bucketName = 'fake-bucket';
     this.client = client;
     this.calls = {};
     this._fails = fails;
+    this._throwError = throwError;
     this._value = value;
     this._consumeStream = consumeStream;
   }
 
   async _invoke(method, args) {
     this.calls[method] = (this.calls[method] || 0) + 1;
+    if (this._throwError) {
+      throw this._throwError;
+    }
     if (this._fails) {
       throw new Error(`${method} failed`);
     }
@@ -165,6 +170,26 @@ describe('MirroringBackend', () => {
         assert.strictEqual(primary.calls[method], 1);
         assert.strictEqual(r2.calls[method], 1);
         assert.strictEqual(azure.calls[method], 1);
+      });
+
+      it('passes a thrown StorageError through unchanged, only prefixing its message', async () => {
+        const cause = new Error('root cause');
+        const storageErr = new StorageError('boom', {
+          status: 500, code: 'X', backend: 'S3', cause,
+        });
+        const primary = new FakeBackend('S3', { throwError: storageErr });
+        const secondary = new FakeBackend('R2');
+        const mirror = new MirroringBackend({ primary, secondaries: [secondary] });
+        await assert.rejects(mirror[method]('foo'), (err) => {
+          assert.strictEqual(err, storageErr);
+          assert.ok(err instanceof StorageError);
+          assert.strictEqual(err.message, '[S3] boom');
+          assert.strictEqual(err.status, 500);
+          assert.strictEqual(err.code, 'X');
+          assert.strictEqual(err.backend, 'S3');
+          assert.strictEqual(err.cause, cause);
+          return true;
+        });
       });
     });
   });

--- a/packages/helix-shared-storage/test/StorageError.test.js
+++ b/packages/helix-shared-storage/test/StorageError.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { StorageError } from '../src/StorageError.js';
+
+describe('StorageError', () => {
+  it('sets message/name/status/code/backend/cause', () => {
+    const cause = new Error('root cause');
+    const err = new StorageError('something failed', {
+      status: 404, code: 'NoSuchKey', backend: 'S3', cause,
+    });
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.name, 'StorageError');
+    assert.strictEqual(err.message, 'something failed');
+    assert.strictEqual(err.status, 404);
+    assert.strictEqual(err.code, 'NoSuchKey');
+    assert.strictEqual(err.backend, 'S3');
+    assert.strictEqual(err.cause, cause);
+  });
+
+  it('leaves status/code/backend/cause undefined when not given', () => {
+    const err = new StorageError('plain failure');
+    assert.strictEqual(err.status, undefined);
+    assert.strictEqual(err.code, undefined);
+    assert.strictEqual(err.backend, undefined);
+    assert.strictEqual(err.cause, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- `S3Backend` and `AzureBackend` normalized thrown SDK errors inconsistently: `get`/`head` rethrew the raw, backend-native error unmodified on non-404 failures; `copy` and single-key `remove` built ad hoc plain `Error`s with `.status` read from a different field per backend (`e.$metadata.httpStatusCode` vs. `e.statusCode`, plus S3's `e.Code === 'NoSuchKey'` check); `put`/`putStream`/`putMeta`/`list`/`browse` had no error handling at all. This forced downstream consumers to duck-type across backend-specific error shapes to answer "what HTTP status did this fail with?" (see adobe/helix-shared#1264 for a real example from `helix-api-service`).
- Adds `StorageError` (`packages/helix-shared-storage/src/StorageError.js`), a normalized `Error` subclass with `status`, `code`, `backend`, and `cause` (the original raw SDK error), exported from `@adobe/helix-shared-storage`.
- Adds two protected helpers to `AbstractStorageBackend` — `_wrapError(e, message, {status, code})` and `_wrapOr404(...)` — so both backends share the wrapping logic and just supply their own SDK-specific status/code extraction.
- Migrates every mandatory `S3Backend`/`AzureBackend` primitive (`get`, `head`, `put`, `putStream`, `putMeta`, `copy`, `remove`, `list`, `browse`) to throw a `StorageError`, preserving all existing messages/behavior (the `copy` 404 special case, the R2 "Deserialization error" quirk in `remove`, etc.) — only the thrown *type* changes.
- `MirroringBackend` needed no code change: it mutates the same error object's `.message` in place when tagging the failing backend, so a thrown `StorageError`'s type and fields already survive unchanged.

## Test plan
- [x] `npm test --workspace=@adobe/helix-shared-storage` — 117 passing, 100% coverage
- [x] `npm test --workspace=@adobe/helix-shared-storage-s3` — 76 passing, 100% coverage
- [x] `npm test --workspace=@adobe/helix-shared-storage-azure` — 46 passing, 100% coverage
- [x] `npm test --workspaces` from repo root — all packages pass, no regressions
- [x] `npm run lint --workspaces` — clean
- [x] New tests cover: `StorageError` construction, `_wrapError`/`_wrapOr404` (fresh wrap, pass-through of an already-`StorageError`, 404→null, non-404→throw), a `StorageError` surviving `MirroringBackend#_fanOutCalls` unchanged, and previously-uncovered error paths (`put`/`putStream`/`putMeta`/`list`/`browse`) for both S3 and Azure backends, plus `.code`/`.cause` passthrough checks
- [x] Two pre-existing S3 tests updated (`assert.rejects(promise, errorInstance)` was asserting `.name`, which is now `'StorageError'` instead of `'Unknown'`/`'Error'`) — replaced with predicate-based assertions

Fixes #1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)