### PR TITLE
feat(queue): add helix-shared-queue base package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Each package releases independently via **semantic-release** with `semantic-rele
 
 ## Packages
 
-Most packages are middleware "wrappers" composed via `@adobe/helix-shared-wrap`'s `.with()` chain on a main handler. A few (`config`, `git`, `storage`, `string`, `utils`, `async`, `process-queue`, `prune`, `tokencache`, `indexer`) are plain libraries.
+Most packages are middleware "wrappers" composed via `@adobe/helix-shared-wrap`'s `.with()` chain on a main handler. A few (`config`, `git`, `storage`, `queue`, `string`, `utils`, `async`, `process-queue`, `prune`, `tokencache`, `indexer`) are plain libraries.
 
 - **helix-shared-async** — Tiny async primitives (`sleep(ms)`, `nextTick()`). Used to yield to the event loop or pause within async flows.
 - **helix-shared-body-data** — Wrap middleware that parses form/JSON request bodies (POST/PUT) and exposes them on `context.data` for Helix Universal serverless functions.
@@ -46,6 +46,7 @@ Most packages are middleware "wrappers" composed via `@adobe/helix-shared-wrap`'
 - **helix-shared-indexer** — HTML-to-record indexer driven by `helix-query.yaml` `indices` config. Resolves CSS selectors, applies value/values expressions (`textContent`, `attribute`, `match`, etc.) to produce queryable records.
 - **helix-shared-process-queue** — Bounded-concurrency async task runner. Takes a list of tasks plus a worker fn; returns aggregated results, with optional access to in-progress results inside the worker.
 - **helix-shared-prune** — `pruneEmptyValues(obj)` recursively strips falsy values and empty arrays from an object in place. Returns `null` when everything is removed; used to keep configs/payloads tidy.
+- **helix-shared-queue** — Pluggable queue abstraction (`QueueService.fromContext(context)` → `.queue(name)` → `Queue` with `send`/`receive`/`delete`), mirroring `helix-shared-storage`'s `Storage`/`Bucket`/`backendFactory` pattern so a concrete provider package (e.g. `@adobe/helix-shared-queue-sqs`) can be swapped in. No cloud SDK dependency in this base package.
 - **helix-shared-secrets** — Wrap middleware that loads secrets (currently AWS Secrets Manager) named `<package>/<function>` into `context` and `process.env` before the handler runs. Supports a custom `nameFunction` for non-default paths.
 - **helix-shared-server-timing** — Wrap middleware that injects a `timer` onto `context`; `timer.update(label)` records milestones and the response automatically gets a `Server-Timing` header.
 - **helix-shared-storage** — `HelixStorage` client over AWS S3 and Cloudflare R2 with `bucket(name).get/put/...`. Most consumers create it from the Helix function `context` rather than direct credentials.

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,10 @@
       "resolved": "packages/helix-shared-prune",
       "link": true
     },
+    "node_modules/@adobe/helix-shared-queue": {
+      "resolved": "packages/helix-shared-queue",
+      "link": true
+    },
     "node_modules/@adobe/helix-shared-secrets": {
       "resolved": "packages/helix-shared-secrets",
       "link": true
@@ -16344,6 +16348,12 @@
       "name": "@adobe/helix-shared-prune",
       "version": "2.0.2",
       "license": "Apache-2.0"
+    },
+    "packages/helix-shared-queue": {
+      "name": "@adobe/helix-shared-queue",
+      "version": "0.0.9",
+      "license": "Apache-2.0",
+      "devDependencies": {}
     },
     "packages/helix-shared-secrets": {
       "name": "@adobe/helix-shared-secrets",

--- a/packages/helix-shared-queue/.mocha-multi.json
+++ b/packages/helix-shared-queue/.mocha-multi.json
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec,xunit",
+    "xunitReporterOptions": {
+        "output": "junit/test-results.xml"
+    }
+}

--- a/packages/helix-shared-queue/.npmignore
+++ b/packages/helix-shared-queue/.npmignore
@@ -1,0 +1,9 @@
+coverage/
+node_modules/
+junit/
+test/
+docs/
+logs/
+test-results.xml
+renovate.json
+.*

--- a/packages/helix-shared-queue/.nycrc.json
+++ b/packages/helix-shared-queue/.nycrc.json
@@ -1,0 +1,10 @@
+{
+  "reporter": [
+    "lcov",
+    "text"
+  ],
+  "check-coverage": true,
+  "lines": 100,
+  "branches": 100,
+  "statements": 100
+}

--- a/packages/helix-shared-queue/LICENSE.txt
+++ b/packages/helix-shared-queue/LICENSE.txt
@@ -1,0 +1,264 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+APACHE JACKRABBIT SUBCOMPONENTS
+
+Apache Jackrabbit includes parts with separate copyright notices and license
+terms. Your use of these subcomponents is subject to the terms and conditions
+of the following licenses:
+
+    XPath 2.0/XQuery 1.0 Parser:
+    http://www.w3.org/2002/11/xquery-xpath-applets/xgrammar.zip
+
+    Copyright (C) 2002 World Wide Web Consortium, (Massachusetts Institute of
+    Technology, European Research Consortium for Informatics and Mathematics,
+    Keio University). All Rights Reserved.
+
+    This work is distributed under the W3C(R) Software License in the hope
+    that it will be useful, but WITHOUT ANY WARRANTY; without even the
+    implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    W3C(R) SOFTWARE NOTICE AND LICENSE
+    http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+    This work (and included software, documentation such as READMEs, or
+    other related items) is being provided by the copyright holders under
+    the following license. By obtaining, using and/or copying this work,
+    you (the licensee) agree that you have read, understood, and will comply
+    with the following terms and conditions.
+
+    Permission to copy, modify, and distribute this software and its
+    documentation, with or without modification, for any purpose and
+    without fee or royalty is hereby granted, provided that you include
+    the following on ALL copies of the software and documentation or
+    portions thereof, including modifications:
+
+       1. The full text of this NOTICE in a location viewable to users
+          of the redistributed or derivative work.
+
+       2. Any pre-existing intellectual property disclaimers, notices,
+          or terms and conditions. If none exist, the W3C Software Short
+          Notice should be included (hypertext is preferred, text is
+          permitted) within the body of any redistributed or derivative code.
+
+       3. Notice of any changes or modifications to the files, including
+          the date changes were made. (We recommend you provide URIs to the
+          location from which the code is derived.)
+
+    THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT
+    HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED,
+    INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS
+    FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR
+    DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+    TRADEMARKS OR OTHER RIGHTS.
+
+    COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL
+    OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR
+    DOCUMENTATION.
+
+    The name and trademarks of copyright holders may NOT be used in
+    advertising or publicity pertaining to the software without specific,
+    written prior permission. Title to copyright in this software and
+    any associated documentation will at all times remain with
+    copyright holders.

--- a/packages/helix-shared-queue/README.md
+++ b/packages/helix-shared-queue/README.md
@@ -70,8 +70,26 @@ const { deleted, failed } = await queue.delete(messages);
 
 Each `message` returned by `receive()` carries an opaque `raw` field with the backend-native message object (e.g. SQS's full message including its `ReceiptHandle`). Pass the same message objects back into `delete()` unmodified — the backend reads whatever ack token it needs off `raw`. `delete()` is best-effort: individual per-message failures are collected into `failed` rather than thrown; only a total, whole-call failure throws.
 
+## Oversized Messages: `isSwapped()` / `deserialize()`
+
+A backend that spills oversized messages to blob storage (see "Notes for Backend Authors" below) does **not** transparently resolve them during `receive()` — `message.body` may be a backend-specific pointer rather than the real content. Check cheaply (no I/O) and resolve only when actually needed:
+
+```js
+const { messages } = await queue.receive();
+for (let message of messages) {
+  if (await queue.isSwapped(message)) {
+    message = await queue.deserialize(message);
+  }
+  console.log(message.body); // guaranteed real now
+}
+await queue.delete(messages);
+```
+
+This split matters for callers that only need a few cheap fields out of a message (e.g. routing metadata) without paying for a blob fetch on every message, swapped or not. `delete()` still cleans up any spilled blob-storage object on ack, whether or not `deserialize()` was ever called for it. Backends that don't support spillover at all inherit safe defaults from `AbstractQueueBackend` (`isSwapped()` always `false`, `deserialize()` returns the message unchanged) — this API works identically (including as a no-op) regardless of which backend is plugged in.
+
 ## Notes for Backend Authors
 
 - **No `MirroringBackend` equivalent.** Storage's `MirroringBackend` fans out writes to multiple backends for read redundancy, which is safe because reads are idempotent. Fanning out `send()` to two independent queue backends would mean *duplicate delivery* to two independent consumer fleets, not redundancy — don't port that pattern here.
 - **Oversized-message spillover is a backend concern.** This package has no dependency on `@adobe/helix-shared-storage` and no opinion on how a backend handles a message too large for its provider's limits. A backend that needs to spill oversized messages to blob storage (as `BatchedQueueClient` did for SQS, hardcoding S3) should accept an injected `Storage`/`Bucket` from `@adobe/helix-shared-storage` for that purpose via its own constructor/backend-factory options, so the spill-storage choice tracks whatever `Storage` backend the host service already configured.
 - **All three `QueueBackend` primitives (`sendBatch`/`receiveBatch`/`deleteBatch`) are mandatory** — there are no generic defaults to inherit from `AbstractQueueBackend`, since batch-size limits, long-poll call shape, and ack-token shape are all inherently provider-specific.
+- **`isSwapped`/`deserialize` do have generic defaults** (always `false` / return the message unchanged), since spillover support is optional — most backends won't need it. A backend that does support spillover should implement both, and have `receiveBatch()` do only the cheap (no I/O) detection step eagerly — computing and stashing whatever it needs (e.g. a storage key) on `raw` — while deferring the actual blob fetch to `deserialize()`. `deleteBatch()` should use that same stashed state to clean up the spilled object on ack, independent of whether `deserialize()` was ever called.

--- a/packages/helix-shared-queue/README.md
+++ b/packages/helix-shared-queue/README.md
@@ -1,0 +1,77 @@
+# Helix Shared - queue
+
+The queue module provides a unified, backend-agnostic interface for sending and receiving messages via a message queue. `QueueService` and `Queue` are configured with a pluggable `QueueBackend` — this package ships no cloud SDK itself; it defines only the interface and a thin `send`/`receive`/`delete` facade on top of it.
+
+The default AWS SQS backend lives in a separate package, `@adobe/helix-shared-queue-sqs`, which most consumers will want to install alongside this one.
+
+## Installation
+
+```bash
+npm install @adobe/helix-shared-queue @adobe/helix-shared-queue-sqs
+```
+
+## Basic Usage
+
+Existing SQS consumers use `QueueServiceSqs`, the `QueueService` subclass pre-wired with the default SQS backend, exported from `@adobe/helix-shared-queue-sqs`:
+
+```js
+import { QueueServiceSqs as QueueService } from '@adobe/helix-shared-queue-sqs';
+
+export async function main(req, context) {
+  const service = QueueService.fromContext(context);
+  const queue = service.queue('my-queue-name');
+
+  const { messageIds } = await queue.send([{ body: JSON.stringify({ hello: 'world' }) }]);
+
+  return new Response(JSON.stringify({ messageIds }));
+}
+```
+
+Consumers who want a different backend (or no cloud SDK dependency at all) construct core's generic `QueueService` directly with an explicit `backendFactory` — a function `(queueName, opts) => QueueBackend`:
+
+```js
+import { QueueService } from '@adobe/helix-shared-queue';
+import { createDefaultBackendFactory } from '@adobe/helix-shared-queue-sqs';
+
+const service = new QueueService({
+  backendFactory: createDefaultBackendFactory(process.env),
+  log: console,
+});
+
+const queue = service.queue('my-queue-name');
+await queue.send([{ body: 'Hello World' }]);
+service.close();
+```
+
+## Sending Messages
+
+```js
+const { messageIds } = await queue.send([
+  { body: 'plain message' },
+  { body: 'ordered message', groupId: 'order-42', dedupId: 'order-42-v1' },
+]);
+```
+
+`groupId`/`dedupId` are named generically rather than after SQS FIFO's `MessageGroupId`/`MessageDeduplicationId`, so a future Azure Service Bus backend can map them onto a session id and native deduplication instead.
+
+## Receiving and Deleting Messages
+
+```js
+const { messages } = await queue.receive({ minTime: 10, maxTime: 30, maxMessages: 100 });
+
+for (const message of messages) {
+  console.log(message.body);
+}
+
+const { deleted, failed } = await queue.delete(messages);
+```
+
+`receive()` long-polls: it keeps polling for at least `minTime` seconds, and if any messages were received in that window, keeps polling for more up to `maxTime` seconds total, stopping early once `maxMessages` is reached.
+
+Each `message` returned by `receive()` carries an opaque `raw` field with the backend-native message object (e.g. SQS's full message including its `ReceiptHandle`). Pass the same message objects back into `delete()` unmodified — the backend reads whatever ack token it needs off `raw`. `delete()` is best-effort: individual per-message failures are collected into `failed` rather than thrown; only a total, whole-call failure throws.
+
+## Notes for Backend Authors
+
+- **No `MirroringBackend` equivalent.** Storage's `MirroringBackend` fans out writes to multiple backends for read redundancy, which is safe because reads are idempotent. Fanning out `send()` to two independent queue backends would mean *duplicate delivery* to two independent consumer fleets, not redundancy — don't port that pattern here.
+- **Oversized-message spillover is a backend concern.** This package has no dependency on `@adobe/helix-shared-storage` and no opinion on how a backend handles a message too large for its provider's limits. A backend that needs to spill oversized messages to blob storage (as `BatchedQueueClient` did for SQS, hardcoding S3) should accept an injected `Storage`/`Bucket` from `@adobe/helix-shared-storage` for that purpose via its own constructor/backend-factory options, so the spill-storage choice tracks whatever `Storage` backend the host service already configured.
+- **All three `QueueBackend` primitives (`sendBatch`/`receiveBatch`/`deleteBatch`) are mandatory** — there are no generic defaults to inherit from `AbstractQueueBackend`, since batch-size limits, long-poll call shape, and ack-token shape are all inherently provider-specific.

--- a/packages/helix-shared-queue/package.json
+++ b/packages/helix-shared-queue/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@adobe/helix-shared-queue",
+  "version": "0.0.9",
+  "description": "Shared modules of the Helix Project - queue",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "test": "c8 mocha",
+    "lint": "eslint .",
+    "clean": "rm -rf package-lock.json node_modules"
+  },
+  "mocha": {
+    "reporter": "mocha-multi-reporters",
+    "reporter-options": "configFile=.mocha-multi.json",
+    "require": [
+      "mocha-suppress-logs"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/helix-shared.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/adobe/helix-shared/issues"
+  },
+  "homepage": "https://github.com/adobe/helix-shared#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {},
+  "dependencies": {}
+}

--- a/packages/helix-shared-queue/src/AbstractQueueBackend.js
+++ b/packages/helix-shared-queue/src/AbstractQueueBackend.js
@@ -18,11 +18,13 @@ import { QueueError } from './QueueError.js';
  * `backendFactory` that produces one `QueueBackend` per queue name; {@link Queue} is a
  * thin, backend-agnostic facade over it.
  *
- * All three primitives below are mandatory, with no generic default implementation in
- * {@link AbstractQueueBackend} — unlike `StorageBackend`'s 7 mandatory + 5 generic-default
- * split, batch-size/payload-size limits, long-poll call shape, and ack-token shape are all
- * inherently provider-specific, so there is nothing safe to implement generically here in
- * terms of the other primitives.
+ * `sendBatch`/`receiveBatch`/`deleteBatch` are mandatory, with no generic default
+ * implementation in {@link AbstractQueueBackend} — unlike `StorageBackend`'s 7 mandatory + 5
+ * generic-default split, batch-size/payload-size limits, long-poll call shape, and ack-token
+ * shape are all inherently provider-specific, so there is nothing safe to implement
+ * generically here in terms of the other primitives. `isSwapped`/`deserialize`, by contrast,
+ * default to a safe no-spillover-support implementation, since spillover is an optional
+ * concern most backends won't need at all.
  *
  * @typedef {Object} QueueBackend
  * @property {string} name backend family tag used for error tagging, e.g. `'SQS'`,
@@ -39,12 +41,26 @@ import { QueueError } from './QueueError.js';
  *   Promise<import('./Queue.js').ReceiveResult>} receiveBatch
  *  long-poll for messages honoring `minTime`/`maxTime`/`maxMessages` — mandatory, no generic
  *  default (the loop shape is similar across backends, but the size/timeout of an individual
- *  poll call is not, so there's nothing safely factorable into a shared default)
+ *  poll call is not, so there's nothing safely factorable into a shared default). A message
+ *  that a backend spilled to blob storage (because it was too large to send inline) is
+ *  returned as-is — still a backend-specific pointer, not transparently resolved — see
+ *  `isSwapped`/`deserialize` below.
  * @property {function(import('./Queue.js').ReceivedMessage[]):
  *   Promise<import('./Queue.js').DeleteResult>} deleteBatch
  *  best-effort acknowledge/delete of previously received messages; must not throw for
  *  individual per-message ack failures (collect them into `DeleteResult.failed` instead),
- *  only for a total, whole-call failure — mandatory
+ *  only for a total, whole-call failure — mandatory. Also responsible for cleaning up any
+ *  spilled blob-storage object a message references, once the message itself is
+ *  successfully acknowledged, regardless of whether `deserialize` was ever called for it.
+ * @property {function(import('./Queue.js').ReceivedMessage): Promise<boolean>} isSwapped
+ *  cheap (no I/O), synchronous-in-practice check for whether a message's `body` is a
+ *  backend-specific spillover pointer rather than the real content — generic default:
+ *  always `false`
+ * @property {function(import('./Queue.js').ReceivedMessage):
+ *   Promise<import('./Queue.js').ReceivedMessage>} deserialize
+ *  if `isSwapped(message)` is true, fetches the real content from blob storage and returns a
+ *  new message with `body` replaced; otherwise returns `message` unchanged — generic
+ *  default: always returns `message` unchanged
  */
 
 /* eslint-disable class-methods-use-this -- mandatory-primitive stubs intentionally ignore `this` */
@@ -89,5 +105,26 @@ export class AbstractQueueBackend {
 
   async deleteBatch() {
     throw new Error('deleteBatch() not implemented');
+  }
+
+  /**
+   * Generic default: this backend never spills messages to blob storage, so nothing is ever
+   * swapped.
+   *
+   * @returns {Promise<boolean>}
+   */
+  async isSwapped() {
+    return false;
+  }
+
+  /**
+   * Generic default: since {@link AbstractQueueBackend#isSwapped} always returns `false` for
+   * this backend, there's never anything to resolve — return `message` unchanged.
+   *
+   * @param {import('./Queue.js').ReceivedMessage} message
+   * @returns {Promise<import('./Queue.js').ReceivedMessage>}
+   */
+  async deserialize(message) {
+    return message;
   }
 }

--- a/packages/helix-shared-queue/src/AbstractQueueBackend.js
+++ b/packages/helix-shared-queue/src/AbstractQueueBackend.js
@@ -77,6 +77,11 @@ export class AbstractQueueBackend {
    * backend's `name`. Passes an already-`QueueError` through unchanged instead of
    * double-wrapping it.
    *
+   * `_`-prefixed rather than a true `#private` method: it must be callable as
+   * `this._wrapError(...)` from within concrete backend subclasses' (e.g. `SqsBackend`)
+   * own method bodies, and `#private` members declared on an ancestor class are not
+   * reachable from a subclass's method bodies at all.
+   *
    * @protected
    * @param {Error} e the raw, caught SDK error
    * @param {string} message normalized message for the new `QueueError` — callers without a

--- a/packages/helix-shared-queue/src/AbstractQueueBackend.js
+++ b/packages/helix-shared-queue/src/AbstractQueueBackend.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { QueueError } from './QueueError.js';
+
+/**
+ * The pluggable queue backend interface. A `QueueBackend` wraps a single queue against a
+ * single provider (SQS, Azure Service Bus, ...). `QueueService` is configured with a
+ * `backendFactory` that produces one `QueueBackend` per queue name; {@link Queue} is a
+ * thin, backend-agnostic facade over it.
+ *
+ * All three primitives below are mandatory, with no generic default implementation in
+ * {@link AbstractQueueBackend} — unlike `StorageBackend`'s 7 mandatory + 5 generic-default
+ * split, batch-size/payload-size limits, long-poll call shape, and ack-token shape are all
+ * inherently provider-specific, so there is nothing safe to implement generically here in
+ * terms of the other primitives.
+ *
+ * @typedef {Object} QueueBackend
+ * @property {string} name backend family tag used for error tagging, e.g. `'SQS'`,
+ *  `'AzureServiceBus'`
+ * @property {string} queueName the queue this backend instance is bound to
+ * @property {*} [client] the backend's native client, if it has a meaningful one to expose
+ *  (e.g. an `SQSClient`)
+ * @property {function(import('./Queue.js').OutboundMessage[]):
+ *   Promise<import('./Queue.js').SendResult>} sendBatch
+ *  send a batch of messages; the backend owns its own batching/chunking against its own
+ *  service limits (SQS's ≤10 msgs/≤256KB per `SendMessageBatchCommand` vs. Azure Service
+ *  Bus's dynamic batch sizing) — mandatory, no generic default
+ * @property {function(import('./Queue.js').ReceiveOptions=):
+ *   Promise<import('./Queue.js').ReceiveResult>} receiveBatch
+ *  long-poll for messages honoring `minTime`/`maxTime`/`maxMessages` — mandatory, no generic
+ *  default (the loop shape is similar across backends, but the size/timeout of an individual
+ *  poll call is not, so there's nothing safely factorable into a shared default)
+ * @property {function(import('./Queue.js').ReceivedMessage[]):
+ *   Promise<import('./Queue.js').DeleteResult>} deleteBatch
+ *  best-effort acknowledge/delete of previously received messages; must not throw for
+ *  individual per-message ack failures (collect them into `DeleteResult.failed` instead),
+ *  only for a total, whole-call failure — mandatory
+ */
+
+/* eslint-disable class-methods-use-this -- mandatory-primitive stubs intentionally ignore `this` */
+/**
+ * Convenience base class for {@link QueueBackend} implementations. Concrete backend
+ * packages (e.g. `@adobe/helix-shared-queue-sqs`) must implement all three primitives —
+ * there are no generic defaults to inherit, unlike `AbstractStorageBackend`.
+ *
+ * @implements {QueueBackend}
+ */
+export class AbstractQueueBackend {
+  /**
+   * Wraps a caught, backend-native SDK error into a {@link QueueError} tagged with this
+   * backend's `name`. Passes an already-`QueueError` through unchanged instead of
+   * double-wrapping it.
+   *
+   * @protected
+   * @param {Error} e the raw, caught SDK error
+   * @param {string} message normalized message for the new `QueueError` — callers without a
+   *  better message should pass `e.message` through verbatim
+   * @param {Object} [fields]
+   * @param {number} [fields.status]
+   * @param {string} [fields.code]
+   * @returns {QueueError}
+   */
+  _wrapError(e, message, { status, code } = {}) {
+    if (e instanceof QueueError) {
+      return e;
+    }
+    return new QueueError(message, {
+      status, code, backend: this.name, cause: e,
+    });
+  }
+
+  async sendBatch() {
+    throw new Error('sendBatch() not implemented');
+  }
+
+  async receiveBatch() {
+    throw new Error('receiveBatch() not implemented');
+  }
+
+  async deleteBatch() {
+    throw new Error('deleteBatch() not implemented');
+  }
+}

--- a/packages/helix-shared-queue/src/Queue.js
+++ b/packages/helix-shared-queue/src/Queue.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * A single outbound message to send via {@link Queue#send}.
+ *
+ * @typedef {Object} OutboundMessage
+ * @property {string} body message payload, verbatim (backend decides wire encoding)
+ * @property {string} [groupId] ordering/session key. Maps onto SQS FIFO's `MessageGroupId`
+ *  today; named generically so a future Azure Service Bus backend can map it onto a session
+ *  id instead.
+ * @property {string} [dedupId] deduplication key. Maps onto SQS FIFO's
+ *  `MessageDeduplicationId` today; named generically so a future Azure Service Bus backend
+ *  can map it onto its own native dedup mechanism instead.
+ */
+
+/**
+ * Result of {@link Queue#send}.
+ *
+ * @typedef {Object} SendResult
+ * @property {string[]} messageIds backend-assigned ids, one per input message, in the same
+ *  order as the input array.
+ */
+
+/**
+ * A single message returned by {@link Queue#receive}. Round-trips through
+ * {@link Queue#delete} to acknowledge — `raw` carries whatever backend-native handle is
+ * needed to ack (SQS's `ReceiptHandle`, a future Azure Service Bus lock token); `Queue`
+ * itself never interprets it.
+ *
+ * @typedef {Object} ReceivedMessage
+ * @property {string} id backend-native message id (e.g. SQS's `MessageId`)
+ * @property {string} body message payload, verbatim
+ * @property {string} [groupId] echoes the ordering/session key that produced this message,
+ *  when the backend can report one
+ * @property {number} [receiveCount] number of times this message has been delivered so far
+ *  (SQS's `ApproximateReceiveCount`), when the backend can report it
+ * @property {*} raw the backend's raw, native SDK message object — opaque to `Queue`;
+ *  required by {@link Queue#delete} to ack this specific message
+ */
+
+/**
+ * Options for {@link Queue#receive}, generalizing `BatchedQueueClient.receive()`'s
+ * long-poll loop: keep polling for at least `minTime` seconds; if anything was received in
+ * that window, keep polling for more up to `maxTime` seconds total; stop early once
+ * `maxMessages` is reached or no time budget remains. Individual poll-call sizing/timeout
+ * (e.g. SQS's 10-messages/20-seconds-per-call caps) is entirely the backend's concern.
+ *
+ * @typedef {Object} ReceiveOptions
+ * @property {number} [minTime=10] seconds to keep long-polling even before anything has been
+ *  received
+ * @property {number} [maxTime=30] once at least one message has been received, keep polling
+ *  for more, up to this many seconds total
+ * @property {number} [maxMessages=1000] stop early once this many messages have been
+ *  received across the whole call
+ */
+
+/**
+ * @typedef {Object} ReceiveResult
+ * @property {ReceivedMessage[]} messages
+ */
+
+/**
+ * Aggregated, best-effort result of {@link Queue#delete}. Never throws for individual
+ * message-ack failures — only for a total, whole-call failure — mirroring
+ * `BatchedQueueClient.delete()`'s "log partial failures, don't throw" semantics.
+ *
+ * @typedef {Object} DeleteResult
+ * @property {ReceivedMessage[]} deleted messages successfully acknowledged/removed
+ * @property {Array<{message: ReceivedMessage, error: Error}>} failed messages that failed to
+ *  delete, paired with the normalized error for each
+ */
+
+/**
+ * @typedef {Object} QueueOptions
+ * @property {import('./AbstractQueueBackend.js').QueueBackend} backend
+ * @property {Console} [log]
+ */
+
+/**
+ * Thin, backend-agnostic facade wrapping a single `QueueBackend` (see
+ * {@link AbstractQueueBackend}). Unlike {@link Bucket} (which hosts significant generic
+ * composition logic on top of its backend's mandatory primitives), `Queue` is a
+ * near-total pass-through: batching/chunking against provider-specific limits (SQS's
+ * ≤10 msgs/≤256KB, Azure Service Bus's dynamic sizing) is the backend's job, not a shared
+ * generic chunker here.
+ */
+export class Queue {
+  /**
+   * @param {QueueOptions} opts
+   */
+  constructor({ backend, log = console }) {
+    this._backend = backend;
+    this._log = log;
+  }
+
+  /** @type {string} the queue name */
+  get name() {
+    return this._backend.queueName;
+  }
+
+  /** @type {Console} */
+  get log() {
+    return this._log;
+  }
+
+  /**
+   * The backend's native client (e.g. an `SQSClient`); throws if the backend has none.
+   *
+   * @returns {*}
+   */
+  get client() {
+    const c = this._backend.client;
+    if (!c) {
+      throw new Error('client is only available for some backends');
+    }
+    return c;
+  }
+
+  /**
+   * Send a batch of messages. The backend owns all batching/chunking against its own
+   * service limits.
+   *
+   * @param {OutboundMessage[]} messages
+   * @returns {Promise<SendResult>}
+   */
+  async send(messages) {
+    const result = await this._backend.sendBatch(messages);
+    this._log.info(`sent ${messages.length} message(s) to queue: ${this.name}`);
+    return result;
+  }
+
+  /**
+   * Long-poll for messages. See {@link ReceiveOptions}.
+   *
+   * @param {ReceiveOptions} [opts]
+   * @returns {Promise<ReceiveResult>}
+   */
+  async receive(opts = {}) {
+    return this._backend.receiveBatch(opts);
+  }
+
+  /**
+   * Best-effort acknowledge/delete of previously received messages.
+   *
+   * @param {ReceivedMessage[]} messages
+   * @returns {Promise<DeleteResult>}
+   */
+  async delete(messages) {
+    return this._backend.deleteBatch(messages);
+  }
+}

--- a/packages/helix-shared-queue/src/Queue.js
+++ b/packages/helix-shared-queue/src/Queue.js
@@ -107,19 +107,23 @@ export class Queue {
   /**
    * @param {QueueOptions} opts
    */
+  #backend;
+
+  #log;
+
   constructor({ backend, log = console }) {
-    this._backend = backend;
-    this._log = log;
+    this.#backend = backend;
+    this.#log = log;
   }
 
   /** @type {string} the queue name */
   get name() {
-    return this._backend.queueName;
+    return this.#backend.queueName;
   }
 
   /** @type {Console} */
   get log() {
-    return this._log;
+    return this.#log;
   }
 
   /**
@@ -128,7 +132,7 @@ export class Queue {
    * @returns {*}
    */
   get client() {
-    const c = this._backend.client;
+    const c = this.#backend.client;
     if (!c) {
       throw new Error('client is only available for some backends');
     }
@@ -143,8 +147,8 @@ export class Queue {
    * @returns {Promise<SendResult>}
    */
   async send(messages) {
-    const result = await this._backend.sendBatch(messages);
-    this._log.info(`sent ${messages.length} message(s) to queue: ${this.name}`);
+    const result = await this.#backend.sendBatch(messages);
+    this.#log.info(`sent ${messages.length} message(s) to queue: ${this.name}`);
     return result;
   }
 
@@ -155,7 +159,7 @@ export class Queue {
    * @returns {Promise<ReceiveResult>}
    */
   async receive(opts = {}) {
-    return this._backend.receiveBatch(opts);
+    return this.#backend.receiveBatch(opts);
   }
 
   /**
@@ -165,7 +169,7 @@ export class Queue {
    * @returns {Promise<DeleteResult>}
    */
   async delete(messages) {
-    return this._backend.deleteBatch(messages);
+    return this.#backend.deleteBatch(messages);
   }
 
   /**
@@ -177,7 +181,7 @@ export class Queue {
    * @returns {Promise<boolean>}
    */
   async isSwapped(message) {
-    return this._backend.isSwapped(message);
+    return this.#backend.isSwapped(message);
   }
 
   /**
@@ -190,6 +194,6 @@ export class Queue {
    * @returns {Promise<ReceivedMessage>}
    */
   async deserialize(message) {
-    return this._backend.deserialize(message);
+    return this.#backend.deserialize(message);
   }
 }

--- a/packages/helix-shared-queue/src/Queue.js
+++ b/packages/helix-shared-queue/src/Queue.js
@@ -37,15 +37,24 @@
  * needed to ack (SQS's `ReceiptHandle`, a future Azure Service Bus lock token); `Queue`
  * itself never interprets it.
  *
+ * `body` may be a backend-specific spillover pointer rather than the real message content,
+ * if the backend spilled it to blob storage because it was too large to send inline —
+ * `receive()` does **not** transparently resolve this (unlike a prior design of this
+ * package): call {@link Queue#isSwapped} to check cheaply (no I/O), and
+ * {@link Queue#deserialize} to fetch the real content only when actually needed. This
+ * split exists so a caller that only needs a few cheap fields out of a large message (e.g.
+ * routing metadata) never pays for the blob fetch.
+ *
  * @typedef {Object} ReceivedMessage
  * @property {string} id backend-native message id (e.g. SQS's `MessageId`)
- * @property {string} body message payload, verbatim
+ * @property {string} body message payload, verbatim — see note above about spillover
  * @property {string} [groupId] echoes the ordering/session key that produced this message,
  *  when the backend can report one
  * @property {number} [receiveCount] number of times this message has been delivered so far
  *  (SQS's `ApproximateReceiveCount`), when the backend can report it
  * @property {*} raw the backend's raw, native SDK message object — opaque to `Queue`;
- *  required by {@link Queue#delete} to ack this specific message
+ *  required by {@link Queue#delete} to ack this specific message, and used by backends to
+ *  privately track spillover state between `isSwapped`/`deserialize`/`delete`
  */
 
 /**
@@ -157,5 +166,30 @@ export class Queue {
    */
   async delete(messages) {
     return this._backend.deleteBatch(messages);
+  }
+
+  /**
+   * Cheap (no I/O) check for whether `message.body` is a backend-specific spillover pointer
+   * rather than the real content. Backends that don't support spillover at all always
+   * return `false` (see {@link AbstractQueueBackend#isSwapped}).
+   *
+   * @param {ReceivedMessage} message
+   * @returns {Promise<boolean>}
+   */
+  async isSwapped(message) {
+    return this._backend.isSwapped(message);
+  }
+
+  /**
+   * If `isSwapped(message)` is true, fetches the real content from blob storage and returns
+   * a new message with `body` replaced; otherwise returns `message` unchanged. Only fetches
+   * when actually called — see the note on {@link ReceivedMessage} for why this is a
+   * separate, opt-in step rather than something `receive()` does automatically.
+   *
+   * @param {ReceivedMessage} message
+   * @returns {Promise<ReceivedMessage>}
+   */
+  async deserialize(message) {
+    return this._backend.deserialize(message);
   }
 }

--- a/packages/helix-shared-queue/src/Queue.js
+++ b/packages/helix-shared-queue/src/Queue.js
@@ -153,6 +153,18 @@ export class Queue {
   }
 
   /**
+   * Convenience wrapper around {@link Queue#send} for the common case of a single message —
+   * `await queue.sendOne(msg)` instead of `(await queue.send([msg])).messageIds[0]`.
+   *
+   * @param {OutboundMessage} message
+   * @returns {Promise<string>} the backend-assigned message id
+   */
+  async sendOne(message) {
+    const { messageIds } = await this.send([message]);
+    return messageIds[0];
+  }
+
+  /**
    * Long-poll for messages. See {@link ReceiveOptions}.
    *
    * @param {ReceiveOptions} [opts]

--- a/packages/helix-shared-queue/src/QueueError.js
+++ b/packages/helix-shared-queue/src/QueueError.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Normalized error thrown by {@link QueueBackend} implementations for any failure that
+ * originates from the underlying provider SDK (SQS, Azure Service Bus, ...). Every backend
+ * wraps its SDK-native error into one of these before throwing, so callers ({@link Queue}
+ * or application code built on `QueueBackend`) can branch on `.status`/`.code` without
+ * knowing which backend they're talking to. The original, raw SDK error is always preserved,
+ * unmodified, as `.cause`.
+ *
+ * @property {number} [status] normalized status code, when the provider has one
+ * @property {string} [code] backend-specific error code, verbatim, when the SDK exposes one
+ * @property {string} [backend] the originating backend's `name` (e.g. `'SQS'`)
+ * @property {Error} [cause] the original, raw, backend-native SDK error, unmodified
+ */
+export class QueueError extends Error {
+  /**
+   * @param {string} message
+   * @param {Object} [opts]
+   * @param {number} [opts.status]
+   * @param {string} [opts.code]
+   * @param {string} [opts.backend]
+   * @param {Error} [opts.cause] passed through to the standard `Error` `cause` option
+   */
+  constructor(message, {
+    status, code, backend, cause,
+  } = {}) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = 'QueueError';
+    this.status = status;
+    this.code = code;
+    this.backend = backend;
+  }
+}

--- a/packages/helix-shared-queue/src/QueueService.js
+++ b/packages/helix-shared-queue/src/QueueService.js
@@ -70,11 +70,17 @@ export class QueueService {
    *
    * @param {QueueServiceOptions} [opts]
    */
+  #log;
+
+  #backendFactory;
+
+  #closed;
+
   constructor(opts = {}) {
     const { log = console, backendFactory } = opts;
-    this._log = log;
-    this._backendFactory = backendFactory;
-    this._closed = false;
+    this.#log = log;
+    this.#backendFactory = backendFactory;
+    this.#closed = false;
   }
 
   /**
@@ -90,13 +96,13 @@ export class QueueService {
    *  `backendFactory` was configured
    */
   queue(queueName, opts = {}) {
-    if (this._closed) {
+    if (this.#closed) {
       throw new Error('queue service already closed.');
     }
     if (!queueName) {
       throw new Error('queueName is required.');
     }
-    if (!this._backendFactory) {
+    if (!this.#backendFactory) {
       throw new Error(
         'No backendFactory configured. Install @adobe/helix-shared-queue-sqs (or another '
         + 'backend package) and pass its factory as `backendFactory`, e.g. '
@@ -104,8 +110,8 @@ export class QueueService {
       );
     }
     return new Queue({
-      backend: this._backendFactory(queueName, opts),
-      log: this._log,
+      backend: this.#backendFactory(queueName, opts),
+      log: this.#log,
     });
   }
 
@@ -115,6 +121,6 @@ export class QueueService {
    * any native clients it created.
    */
   close() {
-    this._closed = true;
+    this.#closed = true;
   }
 }

--- a/packages/helix-shared-queue/src/QueueService.js
+++ b/packages/helix-shared-queue/src/QueueService.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Queue } from './Queue.js';
+
+/**
+ * Options for {@link QueueService}.
+ *
+ * @typedef {Object} QueueServiceOptions
+ * @property {Console} [log] logger; defaults to `console`.
+ * @property {function(string, Object.<string, *>):
+ *   import('./AbstractQueueBackend.js').QueueBackend} [backendFactory]
+ *  factory used to resolve a `QueueBackend` for a given queue name. Backend packages (e.g.
+ *  `@adobe/helix-shared-queue-sqs`) provide this, typically via a convenience `QueueService`
+ *  subclass overriding `fromContext`. The second argument is an opaque bag forwarded
+ *  verbatim from {@link QueueService#queue} — core does not interpret it.
+ */
+
+/**
+ * Helix function context shape used by {@link QueueService.fromContext}. The queue service
+ * instance is cached on `context.attributes.queue`; configuration is read from
+ * `context.env`.
+ *
+ * @typedef {Object} QueueServiceContext
+ * @property {Object.<string, string|undefined>} env
+ * @property {Console} log
+ * @property {Object.<string, *>} attributes
+ */
+
+/**
+ * The QueueService provides a factory for simplified queue operations against a pluggable
+ * queue backend family (e.g. SQS, Azure Service Bus, ...). A single `QueueService` instance
+ * is configured with one `backendFactory`, used to resolve every {@link Queue} it hands out.
+ * This package ships no cloud SDK itself; it defines only the interface and the generic
+ * `send`/`receive`/`delete` facade on top of it.
+ */
+export class QueueService {
+  /**
+   * Get (and lazily construct + cache) a {@link QueueService} for a Helix function
+   * `context`. Caches the resulting instance on `context.attributes.queue` so repeat calls
+   * within the same invocation share it. Uses `new this(...)` so that a subclass (e.g.
+   * `QueueServiceSqs` from `@adobe/helix-shared-queue-sqs`) calling `super.fromContext(...)`
+   * gets an instance of itself, not of the base `QueueService`.
+   *
+   * @param {QueueServiceContext} context
+   * @param {Partial<QueueServiceOptions>} [opts]
+   * @returns {QueueService}
+   */
+  static fromContext(context, opts = {}) {
+    if (!context.attributes.queue) {
+      context.attributes.queue = new this({
+        log: context.log,
+        ...opts,
+      });
+    }
+    return context.attributes.queue;
+  }
+
+  /**
+   * Create a queue service instance.
+   *
+   * @param {QueueServiceOptions} [opts]
+   */
+  constructor(opts = {}) {
+    const { log = console, backendFactory } = opts;
+    this._log = log;
+    this._backendFactory = backendFactory;
+    this._closed = false;
+  }
+
+  /**
+   * Create a {@link Queue} for the given queue name, resolved via the configured
+   * `backendFactory`. `opts` is an opaque bag forwarded verbatim to the `backendFactory` —
+   * core does not interpret it; individual backend packages define whichever options they
+   * support.
+   *
+   * @param {string} queueName
+   * @param {Record<string, unknown>} [opts] backend-specific options, passed through as-is
+   * @returns {Queue}
+   * @throws if the queue service has been closed, if `queueName` is empty, or if no
+   *  `backendFactory` was configured
+   */
+  queue(queueName, opts = {}) {
+    if (this._closed) {
+      throw new Error('queue service already closed.');
+    }
+    if (!queueName) {
+      throw new Error('queueName is required.');
+    }
+    if (!this._backendFactory) {
+      throw new Error(
+        'No backendFactory configured. Install @adobe/helix-shared-queue-sqs (or another '
+        + 'backend package) and pass its factory as `backendFactory`, e.g. '
+        + 'new QueueService({ backendFactory: createDefaultBackendFactory(env) }).',
+      );
+    }
+    return new Queue({
+      backend: this._backendFactory(queueName, opts),
+      log: this._log,
+    });
+  }
+
+  /**
+   * Close this queue service, rendering this instance unusable; subsequent calls to
+   * {@link QueueService#queue} throw. The configured `backendFactory` owns the lifecycle of
+   * any native clients it created.
+   */
+  close() {
+    this._closed = true;
+  }
+}

--- a/packages/helix-shared-queue/src/index.js
+++ b/packages/helix-shared-queue/src/index.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export { QueueService } from './QueueService.js';
+export { Queue } from './Queue.js';
+export { AbstractQueueBackend } from './AbstractQueueBackend.js';
+export { QueueError } from './QueueError.js';

--- a/packages/helix-shared-queue/test/AbstractQueueBackend.test.js
+++ b/packages/helix-shared-queue/test/AbstractQueueBackend.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { AbstractQueueBackend } from '../src/AbstractQueueBackend.js';
+import { QueueError } from '../src/QueueError.js';
+
+class MinimalBackend extends AbstractQueueBackend {
+  // eslint-disable-next-line class-methods-use-this -- fixed tag, like real backends' `name`
+  get name() {
+    return 'Minimal';
+  }
+}
+
+describe('AbstractQueueBackend', () => {
+  describe('_wrapError()', () => {
+    it('wraps a raw error into a QueueError tagged with this.name', () => {
+      const backend = new MinimalBackend();
+      const raw = new Error('boom');
+      // eslint-disable-next-line no-underscore-dangle -- exercising the protected helper directly
+      const wrapped = backend._wrapError(raw, 'wrapped msg', { status: 500, code: 'X' });
+      assert.ok(wrapped instanceof QueueError);
+      assert.strictEqual(wrapped.message, 'wrapped msg');
+      assert.strictEqual(wrapped.status, 500);
+      assert.strictEqual(wrapped.code, 'X');
+      assert.strictEqual(wrapped.backend, 'Minimal');
+      assert.strictEqual(wrapped.cause, raw);
+    });
+
+    it('passes an already-QueueError through unchanged', () => {
+      const backend = new MinimalBackend();
+      const original = new QueueError('original msg', { status: 404, backend: 'Other' });
+      // eslint-disable-next-line no-underscore-dangle -- exercising the protected helper directly
+      const result = backend._wrapError(original, 'other msg', { status: 500 });
+      assert.strictEqual(result, original);
+      assert.strictEqual(result.message, 'original msg');
+      assert.strictEqual(result.status, 404);
+      assert.strictEqual(result.backend, 'Other');
+    });
+  });
+
+  describe('mandatory primitives', () => {
+    const backend = new AbstractQueueBackend();
+
+    ['sendBatch', 'receiveBatch', 'deleteBatch'].forEach((method) => {
+      it(`${method}() throws when not implemented`, async () => {
+        await assert.rejects(backend[method](), new Error(`${method}() not implemented`));
+      });
+    });
+  });
+});

--- a/packages/helix-shared-queue/test/AbstractQueueBackend.test.js
+++ b/packages/helix-shared-queue/test/AbstractQueueBackend.test.js
@@ -58,4 +58,19 @@ describe('AbstractQueueBackend', () => {
       });
     });
   });
+
+  describe('generic defaults', () => {
+    it('isSwapped() always returns false', async () => {
+      const backend = new AbstractQueueBackend();
+      assert.strictEqual(await backend.isSwapped({ id: 'm1', body: 'hello', raw: {} }), false);
+    });
+
+    it('deserialize() returns the message unchanged', async () => {
+      const backend = new AbstractQueueBackend();
+      const message = {
+        id: 'm1', body: 'hello', raw: {},
+      };
+      assert.strictEqual(await backend.deserialize(message), message);
+    });
+  });
 });

--- a/packages/helix-shared-queue/test/Queue.test.js
+++ b/packages/helix-shared-queue/test/Queue.test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { AbstractQueueBackend } from '../src/AbstractQueueBackend.js';
+import { Queue } from '../src/Queue.js';
+
+/**
+ * In-memory fake backend, sufficient to exercise Queue's pass-through behavior without any
+ * real SDK involved.
+ */
+class FakeBackend extends AbstractQueueBackend {
+  constructor({ queueName = 'fake-queue', name = 'Fake', client } = {}) {
+    super();
+    this.queueName = queueName;
+    this.name = name;
+    this.client = client;
+    this.sendCalls = [];
+    this.receiveCalls = [];
+    this.deleteCalls = [];
+  }
+
+  async sendBatch(messages) {
+    this.sendCalls.push(messages);
+    return { messageIds: messages.map((_, i) => `id-${i}`) };
+  }
+
+  async receiveBatch(opts) {
+    this.receiveCalls.push(opts);
+    return { messages: [{ id: 'm1', body: 'hello', raw: { ReceiptHandle: 'rh1' } }] };
+  }
+
+  async deleteBatch(messages) {
+    this.deleteCalls.push(messages);
+    return { deleted: messages, failed: [] };
+  }
+}
+
+describe('Queue', () => {
+  let backend;
+  let queue;
+
+  beforeEach(() => {
+    backend = new FakeBackend();
+    queue = new Queue({ backend, log: console });
+  });
+
+  it('exposes the queue name and log from the backend', () => {
+    assert.strictEqual(queue.name, 'fake-queue');
+    assert.strictEqual(queue.log, console);
+  });
+
+  describe('client', () => {
+    it('throws when the backend has no client', () => {
+      assert.throws(() => queue.client, /client is only available for some backends/);
+    });
+
+    it('returns the backend client when present', () => {
+      backend.client = 'fake-client';
+      assert.strictEqual(queue.client, 'fake-client');
+    });
+  });
+
+  describe('send()', () => {
+    it('forwards to backend.sendBatch() and returns its result verbatim', async () => {
+      const messages = [{ body: 'a' }, { body: 'b', groupId: 'g1', dedupId: 'd1' }];
+      const result = await queue.send(messages);
+      assert.deepStrictEqual(backend.sendCalls, [messages]);
+      assert.deepStrictEqual(result, { messageIds: ['id-0', 'id-1'] });
+    });
+  });
+
+  describe('receive()', () => {
+    it('forwards to backend.receiveBatch() with the given opts', async () => {
+      const result = await queue.receive({ minTime: 1, maxTime: 2, maxMessages: 3 });
+      assert.deepStrictEqual(backend.receiveCalls, [{ minTime: 1, maxTime: 2, maxMessages: 3 }]);
+      assert.deepStrictEqual(result, {
+        messages: [{ id: 'm1', body: 'hello', raw: { ReceiptHandle: 'rh1' } }],
+      });
+    });
+
+    it('defaults opts to an empty object', async () => {
+      await queue.receive();
+      assert.deepStrictEqual(backend.receiveCalls, [{}]);
+    });
+  });
+
+  describe('delete()', () => {
+    it('forwards to backend.deleteBatch() and returns mixed deleted/failed verbatim', async () => {
+      const messages = [{ id: 'm1', raw: { ReceiptHandle: 'rh1' } }];
+      backend.deleteBatch = async (msgs) => ({
+        deleted: [msgs[0]],
+        failed: [{ message: msgs[0], error: new Error('boom') }],
+      });
+      const result = await queue.delete(messages);
+      assert.strictEqual(result.deleted[0], messages[0]);
+      assert.strictEqual(result.failed[0].message, messages[0]);
+      assert.strictEqual(result.failed[0].error.message, 'boom');
+    });
+  });
+});

--- a/packages/helix-shared-queue/test/Queue.test.js
+++ b/packages/helix-shared-queue/test/Queue.test.js
@@ -80,6 +80,15 @@ describe('Queue', () => {
     });
   });
 
+  describe('sendOne()', () => {
+    it('wraps the message in a single-element array and unwraps the resulting id', async () => {
+      const message = { body: 'a' };
+      const messageId = await queue.sendOne(message);
+      assert.deepStrictEqual(backend.sendCalls, [[message]]);
+      assert.strictEqual(messageId, 'id-0');
+    });
+  });
+
   describe('receive()', () => {
     it('forwards to backend.receiveBatch() with the given opts', async () => {
       const result = await queue.receive({ minTime: 1, maxTime: 2, maxMessages: 3 });

--- a/packages/helix-shared-queue/test/Queue.test.js
+++ b/packages/helix-shared-queue/test/Queue.test.js
@@ -108,4 +108,30 @@ describe('Queue', () => {
       assert.strictEqual(result.failed[0].error.message, 'boom');
     });
   });
+
+  describe('isSwapped()', () => {
+    it('delegates to backend.isSwapped()', async () => {
+      backend.isSwapped = async (message) => message.id === 'swapped';
+      assert.strictEqual(await queue.isSwapped({ id: 'swapped' }), true);
+      assert.strictEqual(await queue.isSwapped({ id: 'other' }), false);
+    });
+
+    it('uses the inherited generic default (always false) when not overridden', async () => {
+      assert.strictEqual(await queue.isSwapped({ id: 'm1', body: 'hello', raw: {} }), false);
+    });
+  });
+
+  describe('deserialize()', () => {
+    it('delegates to backend.deserialize()', async () => {
+      const swapped = { id: 'm1', body: 'pointer' };
+      const real = { id: 'm1', body: 'real' };
+      backend.deserialize = async (message) => (message === swapped ? real : message);
+      assert.strictEqual(await queue.deserialize(swapped), real);
+    });
+
+    it('uses the inherited generic default (returns message unchanged) when not overridden', async () => {
+      const message = { id: 'm1', body: 'hello', raw: {} };
+      assert.strictEqual(await queue.deserialize(message), message);
+    });
+  });
 });

--- a/packages/helix-shared-queue/test/QueueError.test.js
+++ b/packages/helix-shared-queue/test/QueueError.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { QueueError } from '../src/QueueError.js';
+
+describe('QueueError', () => {
+  it('sets message/name/status/code/backend/cause', () => {
+    const cause = new Error('root cause');
+    const err = new QueueError('something failed', {
+      status: 404, code: 'QueueDoesNotExist', backend: 'SQS', cause,
+    });
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.name, 'QueueError');
+    assert.strictEqual(err.message, 'something failed');
+    assert.strictEqual(err.status, 404);
+    assert.strictEqual(err.code, 'QueueDoesNotExist');
+    assert.strictEqual(err.backend, 'SQS');
+    assert.strictEqual(err.cause, cause);
+  });
+
+  it('leaves status/code/backend/cause undefined when not given', () => {
+    const err = new QueueError('plain failure');
+    assert.strictEqual(err.status, undefined);
+    assert.strictEqual(err.code, undefined);
+    assert.strictEqual(err.backend, undefined);
+    assert.strictEqual(err.cause, undefined);
+  });
+});

--- a/packages/helix-shared-queue/test/QueueService.test.js
+++ b/packages/helix-shared-queue/test/QueueService.test.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { QueueService } from '../src/QueueService.js';
+
+describe('QueueService', () => {
+  let calls;
+  let service;
+
+  const backendFactory = (queueName, opts) => {
+    calls.push({ queueName, opts });
+    return { queueName, name: 'Fake' };
+  };
+
+  beforeEach(() => {
+    calls = [];
+    service = new QueueService({ backendFactory });
+  });
+
+  afterEach(() => {
+    service.close();
+  });
+
+  it('queue() throws when no backendFactory is configured', () => {
+    const s = new QueueService();
+    assert.throws(
+      () => s.queue('foo'),
+      /No backendFactory configured/,
+    );
+  });
+
+  it('queue() needs a queueName', () => {
+    assert.throws(() => service.queue(), Error('queueName is required.'));
+  });
+
+  it('queue() calls the backendFactory with a forwarded, opaque opts bag', () => {
+    const queue = service.queue('my-queue', { visibilityTimeout: 30 });
+    assert.deepStrictEqual(calls, [{ queueName: 'my-queue', opts: { visibilityTimeout: 30 } }]);
+    assert.strictEqual(queue.name, 'my-queue');
+  });
+
+  it('queue() defaults opts to an empty object', () => {
+    service.queue('my-queue');
+    assert.deepStrictEqual(calls, [{ queueName: 'my-queue', opts: {} }]);
+  });
+
+  it('queue() fails on closed service', () => {
+    service.close();
+    assert.throws(() => service.queue('my-queue'), Error('queue service already closed.'));
+  });
+
+  it('close() is idempotent', () => {
+    service.close();
+    service.close();
+    assert.throws(() => service.queue('my-queue'), Error('queue service already closed.'));
+  });
+
+  it('creates a queue service from context and caches it', () => {
+    const ctx = {
+      env: {},
+      log: console,
+      attributes: {},
+    };
+    const s = QueueService.fromContext(ctx, { backendFactory });
+    assert.ok(s instanceof QueueService);
+    assert.strictEqual(QueueService.fromContext(ctx), s);
+    // second call must not re-construct (asserted indirectly: only one backendFactory call
+    // happens below, on the single queue() invocation)
+    assert.strictEqual(s.queue('my-queue').name, 'my-queue');
+    assert.strictEqual(calls.length, 1);
+  });
+
+  it('fromContext() forwards opts to the constructor', () => {
+    const ctx = {
+      env: {},
+      log: console,
+      attributes: {},
+    };
+    const s = QueueService.fromContext(ctx, { backendFactory });
+    assert.strictEqual(s.queue('my-queue').name, 'my-queue');
+  });
+
+  it('fromContext() lets a subclass compose correctly via new this(...)', () => {
+    class MyQueueService extends QueueService {
+      static fromContext(context, opts = {}) {
+        return super.fromContext(context, { backendFactory, ...opts });
+      }
+    }
+    const ctx = {
+      env: {},
+      log: console,
+      attributes: {},
+    };
+    const s = MyQueueService.fromContext(ctx);
+    assert.ok(s instanceof MyQueueService);
+    assert.strictEqual(MyQueueService.fromContext(ctx), s);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `@adobe/helix-shared-queue`, a pluggable queue abstraction (`QueueService` → `.queue(name)` → `Queue`, backed by an injectable `QueueBackend`/`backendFactory`), mirroring `@adobe/helix-shared-storage`'s `Storage`/`Bucket` pattern so a concrete provider package (e.g. a future `helix-shared-queue-sqs`) can be swapped in without forking `BatchedQueueClient` (`@adobe/helix-admin-support`).
- `Queue#send`/`receive`/`delete` generalize `BatchedQueueClient`'s send/long-poll-receive/batch-delete semantics; `groupId`/`dedupId` are named generically (not SQS's `MessageGroupId`/`MessageDeduplicationId`) so a future Azure Service Bus backend can map them onto session id + native dedup.
- `sendBatch`/`receiveBatch`/`deleteBatch` are fully mandatory on `AbstractQueueBackend` with no generic defaults, since batching limits, long-poll call shape, and ack-token shape are all provider-specific. This base package has zero cloud SDK dependencies.
- **`isSwapped(message)`/`deserialize(message)`** (added after the initial version of this PR, once two concrete backends surfaced the need): a backend that spills oversized messages to blob storage should not have `receive()` transparently fetch every spilled message's real content — that forces an I/O round-trip even when the caller only needed a couple of cheap fields off the message (e.g. `helix-indexer`'s `notify()` reads just `owner`/`repo` without ever touching storage). These two methods let a caller check cheaply (no I/O) and fetch only when actually needed, identically regardless of which backend is plugged in. Both have generic defaults on `AbstractQueueBackend` (`isSwapped` always `false`, `deserialize` returns the message unchanged), since spillover support is optional.
- Updates root `CLAUDE.md` with a package entry.

Addresses #1269. Companion issues #1270 (SQS backend) and #1271 (Azure Service Bus backend) are now implemented in #1274 and #1275 respectively, both depending on this PR.

## Test plan
- [x] `npm run lint` (workspace-wide, 19 projects) passes
- [x] `npm test` (workspace-wide, 19 projects) passes
- [x] New package hits 100% line/branch/statement/function coverage (`.nycrc.json` gate), including `isSwapped()`/`deserialize()`'s delegation and generic-default behavior
- [x] Manually verified the public API shape end-to-end with a fake `backendFactory` (`new QueueService({ backendFactory }).queue('name').send([...])`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
