### PR TITLE
test(async): relax sleep test tolerance to fix flakiness

### DIFF
--- a/packages/helix-shared-async/test/async.test.js
+++ b/packages/helix-shared-async/test/async.test.js
@@ -21,7 +21,7 @@ describe('Async Tests', () => {
     const t0 = Date.now();
     await sleep(20);
     const t = Date.now() - t0;
-    assert(t >= 20 && t <= 1000, `delta was: ${t}`);
+    assert(t >= 19 && t <= 1000, `delta was: ${t}`);
   });
 
   it('nextTick', async () => {


### PR DESCRIPTION
## Summary
- The `sleep` test in `helix-shared-async` intermittently failed with `delta was: 19` because `setTimeout`/libuv truncate their internal monotonic clock to whole milliseconds, so a timer scheduled for 20ms can legitimately fire ~1ms early.
- Relaxed the lower-bound assertion from `t >= 20` to `t >= 19` to tolerate this known, expected timer imprecision while still verifying the sleep actually waited (not `>= 1000` or `0`).

## Test plan
- [x] `npm test` in `packages/helix-shared-async` passes
- [x] `npm test --workspaces` (full monorepo suite) passes with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)